### PR TITLE
Replace topology keys with optional topology aware hints

### DIFF
--- a/charts/spegel/templates/service.yaml
+++ b/charts/spegel/templates/service.yaml
@@ -19,6 +19,10 @@ metadata:
   name: {{ include "spegel.fullname" . }}-registry
   labels:
     {{- include "spegel.labels" . | nindent 4 }}
+  {{- if .Values.service.registry.topologyAwareHintsEnabled }}
+  annotations:
+    service.kubernetes.io/topology-aware-hints: auto
+  {{- end }}
 spec:
   type: NodePort
   selector:
@@ -29,5 +33,3 @@ spec:
       targetPort: registry
       nodePort: {{ .Values.service.registry.nodePort }}
       protocol: TCP
-  topologyKeys:
-    - "kubernetes.io/hostname"

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -32,6 +32,7 @@ service:
     port: 5000
     hostPort: 30020
     nodePort: 30021
+    topologyAwareHintsEnabled: true
   router:
     port: 5001
   metrics:


### PR DESCRIPTION
This change removes the topology keys from the node port service and replaces them with topology hints annotation. This is a best effort feature that the cluster needs to implement. If it does with will try to keep network traffic close to the node. Which is something we want if the fallback node port service is used instead of the local Spegel instance.

Fixes #25 