### PR TITLE
Make priority class name configurable and set a default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 
+- [#29](https://github.com/XenitAB/spegel/pull/29) Make priority class name configurable and set a default value.
+
 ### Changed
 
 ### Deprecated

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -26,6 +26,7 @@ helm upgrade --create-namespace --install --version v0.0.4 spegel oci://ghcr.io/
 | nodeSelector | object | `{}` | Node selector for pod assignment. |
 | podAnnotations | object | `{}` | Annotations to add to the pod. |
 | podSecurityContext | object | `{}` | Security context for the pod. |
+| priorityClassName | string | `"system-node-critical"` | Priority class name to use for the pod. |
 | resources | object | `{}` | Resource requests and limits for the Spegel container. |
 | securityContext | object | `{}` | Security context for the Spegel container. |
 | service.metrics.port | int | `9090` | Port to expose the metrics via the service. |

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -81,6 +81,9 @@ serviceMonitor:
   # -- If true creates a Prometheus Service Monitor.
   enabled: false
 
+# -- Priority class name to use for the pod.
+priorityClassName: system-node-critical
+
 spegel:
   # -- Registries for which mirror configuration will be created.
   registries:


### PR DESCRIPTION
When a new node is created it is preferable that Spegel is the first Pod to start on the node. Setting the priority class on the Spegel pods would prioritize that they are scheduled first on new nodes. By default this priority class name will be set to `system-node-critical` which exists by default in Kubernetes.