### PR TITLE
Only use bootstrap function for initial peer discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 
 ### Changed
+
+- [#42](https://github.com/XenitAB/spegel/pull/42) Only use bootstrap function for initial peer discovery.
  
 ### Deprecated
 


### PR DESCRIPTION
This change is meant to slightly simplify the bootstrap process of the DHT. I am not however certain that this is the correct method.