### PR TITLE
Update `helm` documentation to specify namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ version = 2
 The easiest method to install Spegel is with Helm. 
 
 ```shell
-helm upgrade --create-namespace --install --version v0.0.4 spegel oci://ghcr.io/xenitab/helm-charts/spegel
+helm upgrade --create-namespace --namespace spegel --install --version v0.0.4 spegel oci://ghcr.io/xenitab/helm-charts/spegel
 ```
 
 Refer to the [Helm Chart](./charts/spegel) for detailed configuration documentation.


### PR DESCRIPTION
If `--namespace` isn't specified, spegel will
be created in the `default` namespace.

This patch just updates the readme to make sure
someone testing spegel creates the namespace for
it.