### PR TITLE
Replace multierr with stdlib errors join

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/valyala/fastjson v1.6.4
 	github.com/xenitab/pkg/gin v0.0.5
 	github.com/xenitab/pkg/kubernetes v0.0.2
-	go.uber.org/multierr v1.9.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/sync v0.1.0
 	k8s.io/client-go v0.26.2
@@ -176,6 +175,7 @@ require (
 	go.uber.org/dig v1.16.1 // indirect
 	go.uber.org/fx v1.19.2 // indirect
 	go.uber.org/goleak v1.2.0 // indirect
+	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/arch v0.2.0 // indirect
 	golang.org/x/crypto v0.6.0 // indirect
 	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 // indirect

--- a/internal/mirror/mirror_test.go
+++ b/internal/mirror/mirror_test.go
@@ -94,19 +94,19 @@ func TestInvalidMirrorURL(t *testing.T) {
 
 	registries := stringListToUrlList(t, []string{"ftp://docker.io"})
 	err := AddMirrorConfiguration(context.TODO(), fs, "/etc/containerd/certs.d", registries, mirrors)
-	require.EqualError(t, err, "invalid registry url scheme must be http or https")
+	require.EqualError(t, err, "invalid registry url scheme must be http or https: ftp://docker.io")
 
 	registries = stringListToUrlList(t, []string{"https://docker.io/foo/bar"})
 	err = AddMirrorConfiguration(context.TODO(), fs, "/etc/containerd/certs.d", registries, mirrors)
-	require.EqualError(t, err, "invalid registry url path has to be empty")
+	require.EqualError(t, err, "invalid registry url path has to be empty: https://docker.io/foo/bar")
 
 	registries = stringListToUrlList(t, []string{"https://docker.io?foo=bar"})
 	err = AddMirrorConfiguration(context.TODO(), fs, "/etc/containerd/certs.d", registries, mirrors)
-	require.EqualError(t, err, "invalid registry url query has to be empty")
+	require.EqualError(t, err, "invalid registry url query has to be empty: https://docker.io?foo=bar")
 
 	registries = stringListToUrlList(t, []string{"https://foo@docker.io"})
 	err = AddMirrorConfiguration(context.TODO(), fs, "/etc/containerd/certs.d", registries, mirrors)
-	require.EqualError(t, err, "invalid registry url user has to be empty")
+	require.EqualError(t, err, "invalid registry url user has to be empty: https://foo@docker.io")
 
 }
 


### PR DESCRIPTION
As `errors.Join` is now part of the stdlib since Go 1.20 it is good to remove the need for the multierr dependency.