### PR TITLE
Add registry.k8s.io to registry mirror list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#49](https://github.com/XenitAB/spegel/pull/49) Add registry.k8s.io to registry mirror list.
+
 ### Deprecated
 
 ### Removed

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -85,5 +85,5 @@ spec:
 | spegel.extraMirrorRegistries | list | `[]` | Extra target mirror registries other than Spegel. |
 | spegel.imageFilter | string | `""` | Inclusive mirror filter, any image that does not match the filter will not be advertised by Spegel. |
 | spegel.kubeconfigPath | string | `""` | Path to Kubeconfig credentials, should only be set if Spegel is run in an environment without RBAC. |
-| spegel.registries | list | `["https://docker.io","https://ghcr.io","https://quay.io","https://mcr.microsoft.com","https://public.ecr.aws"]` | Registries for which mirror configuration will be created. |
+| spegel.registries | list | `["https://docker.io","https://ghcr.io","https://quay.io","https://mcr.microsoft.com","https://public.ecr.aws","https://registry.k8s.io"]` | Registries for which mirror configuration will be created. |
 | tolerations | list | `[{"effect":"NoSchedule","operator":"Exists"}]` | Tolerations for pod assignment. |

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -92,6 +92,7 @@ spegel:
     - https://quay.io
     - https://mcr.microsoft.com
     - https://public.ecr.aws
+    - https://registry.k8s.io
   # -- Extra target mirror registries other than Spegel.
   extraMirrorRegistries: []
   # -- Inclusive mirror filter, any image that does not match the filter will not be advertised by Spegel.


### PR DESCRIPTION
Adds registry.k8s.io to the list of registries to mirror. This is the new registry where Kubernetes images will be published.

https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/