### PR TITLE
Filter tracked images to only included mirrored registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#51](https://github.com/XenitAB/spegel/pull/51) Filter tracked images to only included mirrored registries.
+
 ### Security
 
 ## v0.0.4

--- a/main.go
+++ b/main.go
@@ -125,7 +125,7 @@ func run(log logr.Logger, args *arguments) error {
 		return router.Close()
 	})
 	g.Go(func() error {
-		return state.Track(ctx, containerdClient, router, args.ImageFilter)
+		return state.Track(ctx, containerdClient, router, args.Registries, args.ImageFilter)
 	})
 
 	reg, err := registry.NewRegistry(ctx, args.RegistryAddr, containerdClient, router)


### PR DESCRIPTION
Currently all images are tracked and advertised. This is less than optimal as only certain registries are mirrored, This change filters images to only include mirrored registries. 