### PR TITLE
Add gcr.io and k8s.gcr.io registries to default list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#29](https://github.com/XenitAB/spegel/pull/29) Make priority class name configurable and set a default value.
 - [#49](https://github.com/XenitAB/spegel/pull/49) Add registry.k8s.io to registry mirror list.
+- [#56](https://github.com/XenitAB/spegel/pull/56) Add gcr.io and k8s.gcr.io registries to default list.
 
 ### Changed
  

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -85,5 +85,5 @@ spec:
 | spegel.extraMirrorRegistries | list | `[]` | Extra target mirror registries other than Spegel. |
 | spegel.imageFilter | string | `""` | Inclusive mirror filter, any image that does not match the filter will not be advertised by Spegel. |
 | spegel.kubeconfigPath | string | `""` | Path to Kubeconfig credentials, should only be set if Spegel is run in an environment without RBAC. |
-| spegel.registries | list | `["https://docker.io","https://ghcr.io","https://quay.io","https://mcr.microsoft.com","https://public.ecr.aws","https://registry.k8s.io"]` | Registries for which mirror configuration will be created. |
+| spegel.registries | list | `["https://docker.io","https://ghcr.io","https://quay.io","https://mcr.microsoft.com","https://public.ecr.aws","https://gcr.io","https://registry.k8s.io","https://k8s.gcr.io"]` | Registries for which mirror configuration will be created. |
 | tolerations | list | `[{"effect":"NoSchedule","operator":"Exists"}]` | Tolerations for pod assignment. |

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -92,7 +92,9 @@ spegel:
     - https://quay.io
     - https://mcr.microsoft.com
     - https://public.ecr.aws
+    - https://gcr.io
     - https://registry.k8s.io
+    - https://k8s.gcr.io
   # -- Extra target mirror registries other than Spegel.
   extraMirrorRegistries: []
   # -- Inclusive mirror filter, any image that does not match the filter will not be advertised by Spegel.


### PR DESCRIPTION
Adds two new registries to the default list, will remove k8s.gcr.io from the list after it is taken out of service.