### PR TITLE
Fix version number in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ version = 2
 The easiest method to deploy Spegel is with Helm. 
 
 ```shell
-helm upgrade --create-namespace --namespace spegel --install --version v0.0.4 spegel oci://ghcr.io/xenitab/helm-charts/spegel
+helm upgrade --create-namespace --namespace spegel --install --version v0.0.5 spegel oci://ghcr.io/xenitab/helm-charts/spegel
 ```
 
 Refer to the [Helm Chart](./charts/spegel) for detailed configuration documentation.

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -11,7 +11,7 @@ Make sure that you have read and understood the [prerequisites](../../README.md#
 Delpoy Spegel with the Helm CLI.
 
 ```sh
-helm upgrade --create-namespace --namespace spegel --install --version v0.0.4 spegel oci://ghcr.io/xenitab/helm-charts/spegel
+helm upgrade --create-namespace --namespace spegel --install --version v0.0.5 spegel oci://ghcr.io/xenitab/helm-charts/spegel
 ```
 
 ### Flux
@@ -44,7 +44,7 @@ spec:
   chart:
     spec:
       chart: spegel
-      version: "v0.0.4"
+      version: "v0.0.5"
       interval: 5m
       sourceRef:
         kind: HelmRepository

--- a/charts/spegel/README.md.gotmpl
+++ b/charts/spegel/README.md.gotmpl
@@ -12,7 +12,7 @@ Make sure that you have read and understood the [prerequisites](../../README.md#
 Delpoy Spegel with the Helm CLI.
 
 ```sh
-helm upgrade --create-namespace --namespace spegel --install --version v0.0.4 spegel oci://ghcr.io/xenitab/helm-charts/spegel
+helm upgrade --create-namespace --namespace spegel --install --version v0.0.5 spegel oci://ghcr.io/xenitab/helm-charts/spegel
 ```
 
 ### Flux
@@ -45,7 +45,7 @@ spec:
   chart:
     spec:
       chart: spegel
-      version: "v0.0.4"
+      version: "v0.0.5"
       interval: 5m
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
The version number changing was missed in the latest release. In the future we need a better solution for this. This change fixes the documentation to use the lastest version number.