### PR TITLE
Move mirror configuration logic to run as an init container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [#42](https://github.com/XenitAB/spegel/pull/42) Only use bootstrap function for initial peer discovery.
+- [#66](https://github.com/XenitAB/spegel/pull/66) Move mirror configuration logic to run as an init container.
  
 ### Deprecated
 

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -77,8 +77,7 @@ spec:
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
 | serviceMonitor.enabled | bool | `false` | If true creates a Prometheus Service Monitor. |
-| spegel.containerdMirrorAdd | bool | `true` | If true Spegel will add mirror configuration on startup. |
-| spegel.containerdMirrorRemove | bool | `false` | If true Spegel will remove the mirror configuration on shutdown. |
+| spegel.containerdMirrorAdd | bool | `true` | If true Spegel will add mirror configuration to the node. |
 | spegel.containerdNamespace | string | `"k8s.io"` | Containerd namespace where images are stored. |
 | spegel.containerdRegistryConfigPath | string | `"/etc/containerd/certs.d"` | Path to Containerd mirror configuration. |
 | spegel.containerdSock | string | `"/run/containerd/containerd.sock"` | Path to Containerd socket. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -24,21 +24,53 @@ spec:
       serviceAccountName: {{ include "spegel.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      containers:
-      - name: registry
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 12 }}
+      {{- if .Values.spegel.containerdMirrorAdd }}
+      initContainers:
+      - name: configuration
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
         args:
+          - configuration
+          - --containerd-registry-config-path={{ .Values.spegel.containerdRegistryConfigPath }}
+          {{- with .Values.spegel.registries }}
+          - --registries
+          {{- range . }}
+          - {{ . | quote }}
+          {{- end }}
+          {{- end }}
+          - --mirror-registries
+          - http://127.0.0.1:{{ .Values.service.registry.hostPort }}
+          - http://127.0.0.1:{{ .Values.service.registry.nodePort }}
+          {{- with .Values.spegel.additionalMirrorRegistries }}
+          {{- range . }}
+          - {{ . | quote }}
+          {{- end }}
+          {{- end }}
+        volumeMounts:
+          - name: containerd-config
+            mountPath: {{ .Values.spegel.containerdRegistryConfigPath }}
+      {{- end }}
+      containers:
+      - name: registry
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+        args:
+          - registry
           - --registry-addr=:{{ .Values.service.registry.port }}
           - --router-addr=:{{ .Values.service.router.port }}
           - --metrics-addr=:{{ .Values.service.metrics.port }}
+          {{- with .Values.spegel.registries }}
+          - --registries
+          {{- range . }}
+          - {{ . | quote }}
+          {{- end }}
+          {{- end }}
           - --containerd-sock={{ .Values.spegel.containerdSock }}
           - --containerd-namespace={{ .Values.spegel.containerdNamespace }}
-          - --containerd-registry-config-path={{ .Values.spegel.containerdRegistryConfigPath }}
-          - --containerd-mirror-add={{ .Values.spegel.containerdMirrorAdd }}
-          - --containerd-mirror-remove={{ .Values.spegel.containerdMirrorRemove }}
           {{- with .Values.spegel.kubeconfigPath }}
           - --kubeconfig-path={{ . }}
           {{- end }}
@@ -47,20 +79,6 @@ spec:
           {{- with .Values.spegel.imageFilter }}
           - --image-filter
           - {{ . | quote }}
-          {{- end }}
-          {{- with .Values.spegel.registries }}
-          - --registries
-          {{- range . }}
-          - {{ . | quote }}
-          {{- end }}    
-          {{- end }}
-          - --mirror-registries
-          - http://127.0.0.1:{{ .Values.service.registry.hostPort }}
-          - http://127.0.0.1:{{ .Values.service.registry.nodePort }}
-          {{- with .Values.spegel.additionalMirrorRegistries }}
-          {{- range . }}
-          - {{ . | quote }}
-          {{- end }}    
           {{- end }}
         ports:
           - name: registry
@@ -89,18 +107,18 @@ spec:
         volumeMounts:
           - name: containerd-sock
             mountPath: {{ .Values.spegel.containerdSock }}
-          - name: containerd-config
-            mountPath: {{ .Values.spegel.containerdRegistryConfigPath }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
       volumes:
         - name: containerd-sock
           hostPath:
             path: {{ .Values.spegel.containerdSock }}
+        {{- if .Values.spegel.containerdMirrorAdd }}
         - name: containerd-config
           hostPath:
             path: {{ .Values.spegel.containerdRegistryConfigPath }}
             type: DirectoryOrCreate
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -105,9 +105,7 @@ spegel:
   containerdNamespace: "k8s.io"
   # -- Path to Containerd mirror configuration.
   containerdRegistryConfigPath: "/etc/containerd/certs.d"
-  # -- If true Spegel will add mirror configuration on startup.
+  # -- If true Spegel will add mirror configuration to the node.
   containerdMirrorAdd: true
-  # -- If true Spegel will remove the mirror configuration on shutdown.
-  containerdMirrorRemove: false
   # -- Path to Kubeconfig credentials, should only be set if Spegel is run in an environment without RBAC.
   kubeconfigPath: ""


### PR DESCRIPTION
This change moves the mirror configuration from running as part of the main application to running as an init container. This has the minor benefit of not having a host path mount on a long running container. The major reason for doing this is to enable a solution to self bootstrap.

This feature will be implemented in a separate PR. The idea is to have Spegel act as an mutating webhook that mutate any Spegel pods init container to set the image registry to localhost. This solves the bootstrap problem when no Spegel instace exists. When Spegel is up and running the init containers Spegel image will be fetched locally.