### PR TITLE
Fix priority class name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#71](https://github.com/XenitAB/spegel/pull/71) Fix priority class name.
+
 ### Security
 
 ## v0.0.5

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -24,6 +24,7 @@ spec:
       serviceAccountName: {{ include "spegel.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      priorityClassName: {{ .Values.priorityClassName }}
       {{- if .Values.spegel.containerdMirrorAdd }}
       initContainers:
       - name: configuration


### PR DESCRIPTION
For some reason parts of the priority class setting did not make it in the PR. This change adds the missing parameter to the DaemonSet.