### PR TITLE
Fix e2e tests mirror configuration

### DIFF
--- a/e2e/kind-config.yaml
+++ b/e2e/kind-config.yaml
@@ -1,8 +1,5 @@
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
-containerdConfigPatchesJSON6902:
-- |-
-  [{"op": "remove", "path": "/plugins/io.containerd.grpc.v1.cri/registry/mirrors"}]
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry]


### PR DESCRIPTION
Seems like mirror configuration has been removed from kind. This change fixes that issue.