### PR TITLE
Refactor image references with generic implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#107](https://github.com/XenitAB/spegel/pull/107) Refactor image references with generic implementation.
+
 ### Deprecated
 
 ### Removed

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/multiformats/go-multicodec v0.9.0
 	github.com/multiformats/go-multihash v0.2.1
 	github.com/norwoodj/helm-docs v1.11.0
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b
 	github.com/prometheus/client_golang v1.15.1
 	github.com/spf13/afero v1.9.5
@@ -140,7 +141,6 @@ require (
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/onsi/ginkgo/v2 v2.9.2 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/runc v1.1.5 // indirect
 	github.com/opencontainers/runtime-spec v1.1.0-rc.1 // indirect
 	github.com/opencontainers/selinux v1.11.0 // indirect
@@ -200,6 +200,7 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gotest.tools/v3 v3.4.0 // indirect
 	k8s.io/api v0.27.1 // indirect
 	k8s.io/apimachinery v0.27.1 // indirect
 	k8s.io/helm v2.17.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1230,7 +1230,8 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
+gotest.tools/v3 v3.4.0 h1:ZazjZUfuVeZGLAmlKKuyv3IKP5orXcwtOwDQH6YVr6o=
+gotest.tools/v3 v3.4.0/go.mod h1:CtbdzLSsqVhDgMtKsx03ird5YTGB3ar27v0u/yKBW5g=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/oci/distribution.go
+++ b/internal/oci/distribution.go
@@ -1,10 +1,9 @@
-package registry
+package oci
 
 import (
-	"fmt"
 	"regexp"
 
-	"github.com/containerd/containerd/reference"
+	"github.com/opencontainers/go-digest"
 )
 
 // Package is used to parse components from requests which comform with the OCI distribution spec.
@@ -18,81 +17,72 @@ var (
 	blobsRegexDigest    = regexp.MustCompile(`/v2/` + nameRegex.String() + `/blobs/(.*)`)
 )
 
-func manifestWithTagReference(registry, path string) (reference.Spec, bool, error) {
+func manifestWithTagReference(registry, path string) (Image, bool, error) {
 	comps := manifestRegexTag.FindStringSubmatch(path)
 	if len(comps) != 6 {
-		return reference.Spec{}, false, nil
+		return Image{}, false, nil
 	}
-	ref, err := reference.Parse(fmt.Sprintf("%s/%s:%s", registry, comps[1], comps[5]))
-	if err != nil {
-		return reference.Spec{}, true, err
-	}
-	return ref, true, nil
+	img := NewImageWithTag(registry, comps[1], comps[5])
+	return img, true, nil
 }
 
-func manifestWithDigestReference(registry, path string) (reference.Spec, bool, error) {
+func manifestWithDigestReference(registry, path string) (Image, bool, error) {
 	comps := manifestRegexDigest.FindStringSubmatch(path)
 	if len(comps) != 6 {
-		return reference.Spec{}, false, nil
+		return Image{}, false, nil
 	}
-	ref, err := reference.Parse(fmt.Sprintf("%s/%s@%s", registry, comps[1], comps[5]))
-	if err != nil {
-		return reference.Spec{}, true, err
-	}
-	return ref, true, nil
+	img := NewImageWithDigest(registry, comps[1], digest.Digest(comps[5]))
+	return img, true, nil
 }
 
 // ManifestReference parses name and reference components from manifest path and returns an image reference.
 // If path does not match any of the regex patterns false will be returned without an error.
 // /v2/<name>/manifests/<reference>
-func ManifestReference(registry, path string) (reference.Spec, bool, error) {
-	ref, ok, err := manifestWithTagReference(registry, path)
+func ManifestReference(registry, path string) (Image, bool, error) {
+	img, ok, err := manifestWithTagReference(registry, path)
 	if err != nil {
-		return reference.Spec{}, ok, err
+		return Image{}, ok, err
 	}
 	if ok {
-		return ref, ok, nil
+		return img, ok, nil
 	}
-	ref, ok, err = manifestWithDigestReference(registry, path)
+	img, ok, err = manifestWithDigestReference(registry, path)
 	if err != nil {
-		return reference.Spec{}, ok, err
+		return Image{}, ok, err
 	}
 	if ok {
-		return ref, ok, nil
+		return img, ok, nil
 	}
-	return reference.Spec{}, false, nil
+	return Image{}, false, nil
 }
 
 // BlobReference parses name and reference components from blob path and returns and image reference.
 // If path does not match the regex pattern false will be returned without an error.
 // /v2/<name>/blobs/<reference>
-func BlobReference(registry, path string) (reference.Spec, bool, error) {
+func BlobReference(registry, path string) (Image, bool, error) {
 	comps := blobsRegexDigest.FindStringSubmatch(path)
 	if len(comps) != 6 {
-		return reference.Spec{}, false, nil
+		return Image{}, false, nil
 	}
-	ref, err := reference.Parse(fmt.Sprintf("%s/%s@%s", registry, comps[1], comps[5]))
-	if err != nil {
-		return reference.Spec{}, true, err
-	}
-	return ref, true, nil
+	img := NewImageWithDigest(registry, comps[1], digest.Digest(comps[5]))
+	return img, true, nil
 }
 
 // Any reference returns the name and tag or digest for a path whcih matches any of the request paths.
-func AnyReference(registry, path string) (reference.Spec, bool, error) {
-	ref, ok, err := ManifestReference(registry, path)
+func AnyReference(registry, path string) (Image, bool, error) {
+	img, ok, err := ManifestReference(registry, path)
 	if err != nil {
-		return reference.Spec{}, ok, err
+		return Image{}, ok, err
 	}
 	if ok {
-		return ref, ok, nil
+		return img, ok, nil
 	}
-	ref, ok, err = BlobReference(registry, path)
+	img, ok, err = BlobReference(registry, path)
 	if err != nil {
-		return reference.Spec{}, ok, err
+		return Image{}, ok, err
 	}
 	if ok {
-		return ref, ok, nil
+		return img, ok, nil
 	}
-	return reference.Spec{}, false, nil
+	return Image{}, false, nil
 }

--- a/internal/oci/distribution_test.go
+++ b/internal/oci/distribution_test.go
@@ -1,4 +1,4 @@
-package registry
+package oci
 
 import (
 	"testing"
@@ -28,10 +28,10 @@ func TestAnyReference(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ref, ok, err := AnyReference(tt.registry, tt.path)
+			img, ok, err := AnyReference(tt.registry, tt.path)
 			require.NoError(t, err)
 			require.True(t, ok)
-			require.Equal(t, tt.expected, ref.String())
+			require.Equal(t, tt.expected, img.Name)
 		})
 	}
 }

--- a/internal/oci/image.go
+++ b/internal/oci/image.go
@@ -1,0 +1,120 @@
+package oci
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	digest "github.com/opencontainers/go-digest"
+)
+
+type Image struct {
+	Name       string
+	Registry   string
+	Repository string
+	Tag        string
+	Digest     digest.Digest
+}
+
+func NewImageWithTag(registry, repository, tag string) Image {
+	name := fmt.Sprintf("%s/%s:%s", registry, repository, tag)
+	return Image{
+		Name:       name,
+		Registry:   registry,
+		Repository: repository,
+		Tag:        tag,
+	}
+}
+
+func NewImageWithDigest(registry, repository string, dgst digest.Digest) Image {
+	name := fmt.Sprintf("%s/%s@%s", registry, repository, dgst.String())
+	return Image{
+		Name:       name,
+		Registry:   registry,
+		Repository: repository,
+		Digest:     dgst,
+	}
+}
+
+func (i Image) Key() string {
+	if i.Digest.String() != "" {
+		return i.Digest.String()
+	}
+	return i.Name
+}
+
+func (i Image) TagReference() (string, bool) {
+	if i.Tag == "" {
+		return "", false
+	}
+	return fmt.Sprintf("%s/%s:%s", i.Registry, i.Repository, i.Tag), true
+}
+
+var splitRe = regexp.MustCompile(`[:@]`)
+
+func ParseWithDigest(s string, dgst digest.Digest) (Image, error) {
+	img, err := Parse(s)
+	if err != nil {
+		return Image{}, err
+	}
+	if img.Digest == "" {
+		img.Digest = dgst
+	}
+	if img.Digest != dgst {
+		return Image{}, fmt.Errorf("invalid digest set does not match parsed digest: %v %v", s, dgst)
+	}
+	return img, nil
+}
+
+func Parse(s string) (Image, error) {
+	if strings.Contains(s, "://") {
+		return Image{}, fmt.Errorf("invalid reference")
+	}
+	u, err := url.Parse("dummy://" + s)
+	if err != nil {
+		return Image{}, err
+	}
+	if u.Scheme != "dummy" {
+		return Image{}, fmt.Errorf("invalid reference")
+	}
+	if u.Host == "" {
+		return Image{}, fmt.Errorf("hostname required")
+	}
+	var object string
+	if idx := splitRe.FindStringIndex(u.Path); idx != nil {
+		// This allows us to retain the @ to signify digests or shortened digests in
+		// the object.
+		object = u.Path[idx[0]:]
+		if object[:1] == ":" {
+			object = object[1:]
+		}
+		u.Path = u.Path[:idx[0]]
+	}
+	tag, dgst := splitObject(object)
+	tag, _, _ = strings.Cut(tag, "@")
+	img := Image{
+		Name:       s,
+		Registry:   u.Host,
+		Repository: strings.TrimPrefix(u.Path, "/"),
+		Tag:        tag,
+		Digest:     dgst,
+	}
+
+	if img.Tag == "" && img.Digest == "" {
+		return Image{}, fmt.Errorf("reference needs to contain a tag or digest")
+	}
+	if img.Registry == "" {
+		return Image{}, fmt.Errorf("reference needs to contain a registry")
+	}
+
+	return img, nil
+}
+
+func splitObject(obj string) (tag string, dgst digest.Digest) {
+	parts := strings.SplitAfterN(obj, "@", 2)
+	if len(parts) < 2 {
+		return parts[0], ""
+	}
+	return parts[0], digest.Digest(parts[1])
+}

--- a/internal/oci/image_test.go
+++ b/internal/oci/image_test.go
@@ -1,0 +1,67 @@
+package oci
+
+import (
+	"fmt"
+	"testing"
+
+	digest "github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseImage(t *testing.T) {
+	tests := []struct {
+		name               string
+		image              string
+		expectedRepository string
+		expectedTag        string
+		expectedDigest     digest.Digest
+	}{
+		{
+			name:               "Latest tag",
+			image:              "library/ubuntu:latest",
+			expectedRepository: "library/ubuntu",
+			expectedTag:        "latest",
+			expectedDigest:     "",
+		},
+		{
+			name:               "Only tag",
+			image:              "library/alpine:3.18.0",
+			expectedRepository: "library/alpine",
+			expectedTag:        "3.18.0",
+			expectedDigest:     "",
+		},
+		{
+			name:               "Tag and digest",
+			image:              "jetstack/cert-manager-controller:3.18.0@sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda",
+			expectedRepository: "jetstack/cert-manager-controller",
+			expectedTag:        "3.18.0",
+			expectedDigest:     digest.Digest("sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda"),
+		},
+		{
+			name:               "Only digest",
+			image:              "fluxcd/helm-controller@sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda",
+			expectedRepository: "fluxcd/helm-controller",
+			expectedTag:        "",
+			expectedDigest:     digest.Digest("sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda"),
+		},
+	}
+	registries := []string{"docker.io", "quay.io", "ghcr.com", "127.0.0.1"}
+	for _, registry := range registries {
+		for _, tt := range tests {
+			t.Run(fmt.Sprintf("%s_%s", tt.name, registry), func(t *testing.T) {
+				img, err := Parse(fmt.Sprintf("%s/%s", registry, tt.image))
+				require.NoError(t, err)
+				require.Equal(t, registry, img.Registry)
+				require.Equal(t, tt.expectedRepository, img.Repository)
+				require.Equal(t, tt.expectedTag, img.Tag)
+				require.Equal(t, tt.expectedDigest, img.Digest)
+			})
+
+		}
+	}
+}
+
+func TestParseImageNoTagOrDigest(t *testing.T) {
+	_, err := Parse("ghcr.io/xenitab/spegel")
+	require.EqualError(t, err, "reference needs to contain a tag or digest")
+}


### PR DESCRIPTION
This is an attempt to remove hard dependencies towards Containerd. Creating a separate type that contains image information will also enable for easier test abiltiy.