### PR TITLE
Remove image filter configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- [#113](https://github.com/XenitAB/spegel/pull/113) Remove image filter configuration.
+
 ### Fixed
 
 ### Security

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -82,7 +82,6 @@ spec:
 | spegel.containerdRegistryConfigPath | string | `"/etc/containerd/certs.d"` | Path to Containerd mirror configuration. |
 | spegel.containerdSock | string | `"/run/containerd/containerd.sock"` | Path to Containerd socket. |
 | spegel.extraMirrorRegistries | list | `[]` | Extra target mirror registries other than Spegel. |
-| spegel.imageFilter | string | `""` | Inclusive mirror filter, any image that does not match the filter will not be advertised by Spegel. |
 | spegel.kubeconfigPath | string | `""` | Path to Kubeconfig credentials, should only be set if Spegel is run in an environment without RBAC. |
 | spegel.registries | list | `["https://docker.io","https://ghcr.io","https://quay.io","https://mcr.microsoft.com","https://public.ecr.aws","https://gcr.io","https://registry.k8s.io","https://k8s.gcr.io"]` | Registries for which mirror configuration will be created. |
 | tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoExecute","operator":"Exists"},{"effect":"NoSchedule","operator":"Exists"}]` | Tolerations for pod assignment. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -77,10 +77,6 @@ spec:
           {{- end }}
           - --leader-election-namespace={{ .Release.Namespace }}
           - --leader-election-name={{ .Release.Namespace }}-leader-election
-          {{- with .Values.spegel.imageFilter }}
-          - --image-filter
-          - {{ . | quote }}
-          {{- end }}
         ports:
           - name: registry
             containerPort: {{ .Values.service.registry.port }}

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -103,8 +103,6 @@ spegel:
     - https://k8s.gcr.io
   # -- Extra target mirror registries other than Spegel.
   extraMirrorRegistries: []
-  # -- Inclusive mirror filter, any image that does not match the filter will not be advertised by Spegel.
-  imageFilter: ""
   # -- Path to Containerd socket.
   containerdSock: "/run/containerd/containerd.sock"
   # -- Containerd namespace where images are stored.

--- a/internal/oci/containerd_test.go
+++ b/internal/oci/containerd_test.go
@@ -11,7 +11,6 @@ func TestCreateFilter(t *testing.T) {
 	tests := []struct {
 		name                string
 		registries          []string
-		imageFilter         string
 		expectedListFilter  string
 		expectedEventFilter string
 	}{
@@ -24,15 +23,14 @@ func TestCreateFilter(t *testing.T) {
 		{
 			name:                "additional image filtes",
 			registries:          []string{"https://docker.io", "https://gcr.io"},
-			imageFilter:         "xenitab/spegel",
-			expectedListFilter:  `name~="docker.io|gcr.io|xenitab/spegel"`,
-			expectedEventFilter: `topic~="/images/create|/images/update",event.name~="docker.io|gcr.io|xenitab/spegel"`,
+			expectedListFilter:  `name~="docker.io|gcr.io"`,
+			expectedEventFilter: `topic~="/images/create|/images/update",event.name~="docker.io|gcr.io"`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			listFilter, eventFilter := createFilters(utils.StringListToUrlList(t, tt.registries), tt.imageFilter)
+			listFilter, eventFilter := createFilters(utils.StringListToUrlList(t, tt.registries))
 			require.Equal(t, listFilter, tt.expectedListFilter)
 			require.Equal(t, eventFilter, tt.expectedEventFilter)
 		})

--- a/main.go
+++ b/main.go
@@ -39,7 +39,6 @@ type RegistryCmd struct {
 	RouterAddr              string    `arg:"--router-addr,required" help:"address to serve router."`
 	MetricsAddr             string    `arg:"--metrics-addr,required" help:"address to serve metrics."`
 	Registries              []url.URL `arg:"--registries,required" help:"registries that are configured to be mirrored."`
-	ImageFilter             string    `arg:"--image-filter" help:"inclusive image name filter."`
 	ContainerdSock          string    `arg:"--containerd-sock" default:"/run/containerd/containerd.sock" help:"Endpoint of containerd service."`
 	ContainerdNamespace     string    `arg:"--containerd-namespace" default:"k8s.io" help:"Containerd namespace to fetch images from."`
 	KubeconfigPath          string    `arg:"--kubeconfig-path" help:"Path to the kubeconfig file."`
@@ -101,7 +100,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 	if err != nil {
 		return err
 	}
-	ociClient, err := oci.NewContainerd(args.ContainerdSock, args.ContainerdNamespace, args.Registries, args.ImageFilter)
+	ociClient, err := oci.NewContainerd(args.ContainerdSock, args.ContainerdNamespace, args.Registries)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I have decided to remove the image filter configuration for now. The reason for this is I am partly unsure how useful it is while at the same time it is Containerd specific. As I have refactored the OCI implementation to support more solutions I want to keep configuration generic. 

I will revisit this in the future after implementing support for a second OCI client, and implement a generic configuration method that would work for both.