### PR TITLE
Fix event name parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,18 @@ e2e: docker-build
 	# Deploy test Nginx pods and verify deployment status
 	kubectl --kubeconfig $$KIND_KUBECONFIG apply -f ./e2e/test-nginx.yaml
 	kubectl --kubeconfig $$KIND_KUBECONFIG --namespace nginx get pods
-	kubectl --kubeconfig $$KIND_KUBECONFIG --namespace nginx wait --timeout=90s deployment/nginx-tag --for condition=available
-	kubectl --kubeconfig $$KIND_KUBECONFIG --namespace nginx wait --timeout=90s deployment/nginx-digest --for condition=available
-	kubectl --kubeconfig $$KIND_KUBECONFIG --namespace nginx wait --timeout=90s deployment/nginx-tag-and-digest --for condition=available
-	kubectl --kubeconfig $$KIND_KUBECONFIG --namespace nginx wait --timeout=90s -l app=nginx-not-present --for jsonpath='{.status.containerStatuses[*].state.waiting.reason}'=ImagePullBackOff pod
+	kubectl --kubeconfig $$KIND_KUBECONFIG --namespace nginx wait --timeout=30s deployment/nginx-tag --for condition=available
+	kubectl --kubeconfig $$KIND_KUBECONFIG --namespace nginx wait --timeout=30s deployment/nginx-digest --for condition=available
+	kubectl --kubeconfig $$KIND_KUBECONFIG --namespace nginx wait --timeout=30s deployment/nginx-tag-and-digest --for condition=available
+	kubectl --kubeconfig $$KIND_KUBECONFIG --namespace nginx wait --timeout=30s -l app=nginx-not-present --for jsonpath='{.status.containerStatuses[*].state.waiting.reason}'=ImagePullBackOff pod
+
+	# Verify that Spegel has never restarted
+	RESTART_COUNT=$$(kubectl --kubeconfig $$KIND_KUBECONFIG --namespace spegel get pods -o=jsonpath='{.items[*].status.containerStatuses[0].restartCount}')
+	if [[ $$RESTART_COUNT != "0 0 0 0" ]]
+	then
+		echo "Spegel should not have restarted during tests."
+		exit 1
+	fi
 
 	# Delete cluster
 	kind delete cluster


### PR DESCRIPTION
When upgrading to Containerd 1.7 event name parsing did not work. This change fixes it and validates that Spegel does not crash during the test run.