### PR TITLE
Refactor registry implementation to not require separate handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#107](https://github.com/XenitAB/spegel/pull/107) Refactor image references with generic implementation.
 - [#114](https://github.com/XenitAB/spegel/pull/114) Move mirror configuration to specific OCI implementation.
 - [#117](https://github.com/XenitAB/spegel/pull/117) Update Containerd client to 1.7.
+- [#126](https://github.com/XenitAB/spegel/pull/126) Refactor registry implementation to not require separate handler.
 
 ### Deprecated
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/spf13/afero v1.9.5
 	github.com/stretchr/testify v1.8.4
 	github.com/xenitab/pkg/channels v0.0.1
-	github.com/xenitab/pkg/gin v0.0.8
+	github.com/xenitab/pkg/gin v0.0.9
 	github.com/xenitab/pkg/kubernetes v0.0.4
 	go.uber.org/zap v1.24.0
 	golang.org/x/sync v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -740,8 +740,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xenitab/pkg/channels v0.0.1 h1:W6LBi4N5XaUhEEj0FGKIpigZK6gVWkouuuOXFp7sVpw=
 github.com/xenitab/pkg/channels v0.0.1/go.mod h1:/MCBlje0/98BdAF7LetkSK1+lXeUpScIbTENGaWjGRg=
-github.com/xenitab/pkg/gin v0.0.8 h1:bT8FYlnk1a6Yue8hYDDotTrwXpKFRjf7hNSoqIf/JVw=
-github.com/xenitab/pkg/gin v0.0.8/go.mod h1:8rzqJ8X5KJOo31PBOD4/Wtlt2ac8hCjN1mpOf1YAFs4=
+github.com/xenitab/pkg/gin v0.0.9 h1:BGdxnKoXAJBkthQTwQdaRdN7jTiNO+/C8hIexBrasfU=
+github.com/xenitab/pkg/gin v0.0.9/go.mod h1:8rzqJ8X5KJOo31PBOD4/Wtlt2ac8hCjN1mpOf1YAFs4=
 github.com/xenitab/pkg/kubernetes v0.0.4 h1:muVWzci89l611bd4FzWlDsHm2zwwzNpxA2TvY9svebI=
 github.com/xenitab/pkg/kubernetes v0.0.4/go.mod h1:nHVulEumb0KUBPMto075ufdEpkQSn8X44ssUwZ+mH0c=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	"github.com/xenitab/spegel/internal/routing"
 )
@@ -60,11 +59,7 @@ func TestMirrorHandler(t *testing.T) {
 		"last-peer-working": {badSvr.URL, badSvr.URL, goodSvr.URL},
 	}
 	router := routing.NewMockRouter(resolver)
-	handler := RegistryHandler{
-		log:           logr.Discard(),
-		router:        router,
-		mirrorRetries: 3,
-	}
+	reg := NewRegistry(nil, router, 3)
 
 	tests := []struct {
 		name            string
@@ -116,7 +111,7 @@ func TestMirrorHandler(t *testing.T) {
 				c, _ := gin.CreateTestContext(rw)
 				target := fmt.Sprintf("http://example.com/%s", tt.key)
 				c.Request = httptest.NewRequest(method, target, nil)
-				handler.handleMirror(c, tt.key)
+				reg.handleMirror(c, tt.key)
 
 				resp := rw.Result()
 				defer resp.Body.Close()


### PR DESCRIPTION
The registry was overly complicated with a separate handler struct. This change simplifies this implementation.