### PR TITLE
Add configuration for resolve retry and timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 
 - [#125](https://github.com/XenitAB/spegel/pull/125) Add retry mirroring to new peer if current peer fails.
+- [#127](https://github.com/XenitAB/spegel/pull/127) Add configuration for resolve retry and timeout.
 
 ### Changed
 

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -83,5 +83,7 @@ spec:
 | spegel.containerdSock | string | `"/run/containerd/containerd.sock"` | Path to Containerd socket. |
 | spegel.extraMirrorRegistries | list | `[]` | Extra target mirror registries other than Spegel. |
 | spegel.kubeconfigPath | string | `""` | Path to Kubeconfig credentials, should only be set if Spegel is run in an environment without RBAC. |
+| spegel.mirrorResolveRetries | int | `3` | Max ammount of mirrors to attempt. |
+| spegel.mirrorResolveTimeout | string | `"5s"` | Max duration spent finding a mirror. |
 | spegel.registries | list | `["https://docker.io","https://ghcr.io","https://quay.io","https://mcr.microsoft.com","https://public.ecr.aws","https://gcr.io","https://registry.k8s.io","https://k8s.gcr.io"]` | Registries for which mirror configuration will be created. |
 | tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoExecute","operator":"Exists"},{"effect":"NoSchedule","operator":"Exists"}]` | Tolerations for pod assignment. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -61,6 +61,8 @@ spec:
           {{- toYaml .Values.securityContext | nindent 12 }}
         args:
           - registry
+          - --mirror-resolve-retries={{ .Values.spegel.mirrorResolveRetries }}
+          - --mirror-resolve-timeout={{ .Values.spegel.mirrorResolveTimeout }}
           - --registry-addr=:{{ .Values.service.registry.port }}
           - --router-addr=:{{ .Values.service.router.port }}
           - --metrics-addr=:{{ .Values.service.metrics.port }}

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -103,6 +103,10 @@ spegel:
     - https://k8s.gcr.io
   # -- Extra target mirror registries other than Spegel.
   extraMirrorRegistries: []
+  # -- Max ammount of mirrors to attempt.
+  mirrorResolveRetries: 3
+  # -- Max duration spent finding a mirror.
+  mirrorResolveTimeout: "5s"
   # -- Path to Containerd socket.
   containerdSock: "/run/containerd/containerd.sock"
   # -- Containerd namespace where images are stored.

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
@@ -59,7 +60,7 @@ func TestMirrorHandler(t *testing.T) {
 		"last-peer-working": {badSvr.URL, badSvr.URL, goodSvr.URL},
 	}
 	router := routing.NewMockRouter(resolver)
-	reg := NewRegistry(nil, router, 3)
+	reg := NewRegistry(nil, router, 3, 5*time.Second)
 
 	tests := []struct {
 		name            string


### PR DESCRIPTION
This change allows end users to change how many times a mirror request should be retried and for how long.