### PR TITLE
Extend tests to validate single node and mirror fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#114](https://github.com/XenitAB/spegel/pull/114) Move mirror configuration to specific OCI implementation.
 - [#117](https://github.com/XenitAB/spegel/pull/117) Update Containerd client to 1.7.
 - [#126](https://github.com/XenitAB/spegel/pull/126) Refactor registry implementation to not require separate handler.
+- [#132](https://github.com/XenitAB/spegel/pull/132) Extend tests to validate single node and mirror fallback.
 
 ### Deprecated
 

--- a/e2e/kind-config.yaml
+++ b/e2e/kind-config.yaml
@@ -14,10 +14,20 @@ containerdConfigPatches:
     content_sharing_policy = "isolated"
 nodes:
   - role: control-plane
-  - role: worker
+    labels:
+      spegel: schedule
   - role: worker
     labels:
+      spegel: schedule
+  - role: worker
+    labels:
+      spegel: schedule
       test: true
   - role: worker
     labels:
+      spegel: schedule
+      test: true
+  - role: worker
+    labels:
+      spegel: schedule
       test: true


### PR DESCRIPTION
Currently there are no tests that validate the fallback method or running a single instance of Spegel. This change add additional validation to the e2e tests. These are important for the future to validate optimizations to the bootstrap process.