### PR TITLE
Use routing table size for readiness check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#117](https://github.com/XenitAB/spegel/pull/117) Update Containerd client to 1.7.
 - [#126](https://github.com/XenitAB/spegel/pull/126) Refactor registry implementation to not require separate handler.
 - [#132](https://github.com/XenitAB/spegel/pull/132) Extend tests to validate single node and mirror fallback.
+- [#133](https://github.com/XenitAB/spegel/pull/133) Use routing table size for readiness check.
 
 ### Deprecated
 

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,14 @@ e2e: docker-build
 		exit 1
 	fi
 
+	# Verify that Spegel has never restarted
+	RESTART_COUNT=$$(kubectl --kubeconfig $$KIND_KUBECONFIG --namespace spegel get pods -o=jsonpath='{.items[*].status.containerStatuses[0].restartCount}')
+	if [[ $$RESTART_COUNT != "0" ]]
+	then
+		echo "Spegel should not have restarted during tests."
+		exit 1
+	fi
+
 	# Delete cluster
 	kind delete cluster
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -71,6 +71,17 @@ func (r *Registry) Server(addr string, log logr.Logger) *http.Server {
 }
 
 func (r *Registry) readyHandler(c *gin.Context) {
+	ok, err := r.router.HasMirrors()
+	if err != nil {
+		//nolint:errcheck // ignore
+		c.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+	if !ok {
+		c.Status(http.StatusInternalServerError)
+		return
+
+	}
 	c.Status(http.StatusOK)
 }
 
@@ -139,7 +150,6 @@ func (r *Registry) registryHandler(c *gin.Context) {
 	c.Status(http.StatusNotFound)
 }
 
-// TODO: Explore if it is worth returning early if router is not populated.
 func (r *Registry) handleMirror(c *gin.Context, key string) {
 	c.Set("handler", "mirror")
 

--- a/internal/routing/mock.go
+++ b/internal/routing/mock.go
@@ -18,6 +18,10 @@ func (m *MockRouter) Close() error {
 	return nil
 }
 
+func (m *MockRouter) HasMirrors() (bool, error) {
+	return true, nil
+}
+
 func (m *MockRouter) Resolve(ctx context.Context, key string, allowSelf bool, count int) (<-chan string, error) {
 	peerCh := make(chan string, count)
 	peers, ok := m.resolver[key]

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -11,4 +11,5 @@ type Router interface {
 	Close() error
 	Resolve(ctx context.Context, key string, allowSelf bool, count int) (<-chan string, error)
 	Advertise(ctx context.Context, keys []string) error
+	HasMirrors() (bool, error)
 }


### PR DESCRIPTION
Currently the registry immediately reports ready, meaning that mirror requests are sent to a Spegel instance even if it does not have any peers. This could create issues as a not ready Spegel instance could be used as a fallback node. This will only affect the initial request that should be mirrored and not forwarded requests. This is because an unready instance will still be able to serve content that it has stored locally. 