### PR TITLE
Switch to using single service with fallback policy for all requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#126](https://github.com/XenitAB/spegel/pull/126) Refactor registry implementation to not require separate handler.
 - [#132](https://github.com/XenitAB/spegel/pull/132) Extend tests to validate single node and mirror fallback.
 - [#133](https://github.com/XenitAB/spegel/pull/133) Use routing table size for readiness check.
+- [#134](https://github.com/XenitAB/spegel/pull/134) Switch to using single service with fallback policy for all requests.
 
 ### Deprecated
 

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -69,10 +69,8 @@ spec:
 | resources | object | `{}` | Resource requests and limits for the Spegel container. |
 | securityContext | object | `{}` | Security context for the Spegel container. |
 | service.metrics.port | int | `9090` | Port to expose the metrics via the service. |
-| service.registry.hostPort | int | `30020` | Local host port to expose the registry. |
 | service.registry.nodePort | int | `30021` | Node port to expose the registry via the service. |
 | service.registry.port | int | `5000` | Port to expose the registry via the service. |
-| service.registry.topologyAwareHintsEnabled | bool | `true` | If true adds topology aware hints annotation to node port service. |
 | service.router.port | int | `5001` | Port to expose the router via the service. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -42,7 +42,6 @@ spec:
           {{- end }}
           {{- end }}
           - --mirror-registries
-          - http://127.0.0.1:{{ .Values.service.registry.hostPort }}
           - http://127.0.0.1:{{ .Values.service.registry.nodePort }}
           {{- with .Values.spegel.additionalMirrorRegistries }}
           {{- range . }}
@@ -82,8 +81,6 @@ spec:
         ports:
           - name: registry
             containerPort: {{ .Values.service.registry.port }}
-            hostIP: "127.0.0.1"    
-            hostPort: {{ .Values.service.registry.hostPort }}
             protocol: TCP
           - name: router
             containerPort: {{ .Values.service.router.port }}

--- a/charts/spegel/templates/service.yaml
+++ b/charts/spegel/templates/service.yaml
@@ -19,12 +19,9 @@ metadata:
   name: {{ include "spegel.fullname" . }}-registry
   labels:
     {{- include "spegel.labels" . | nindent 4 }}
-  {{- if .Values.service.registry.topologyAwareHintsEnabled }}
-  annotations:
-    service.kubernetes.io/topology-aware-hints: auto
-  {{- end }}
 spec:
   type: NodePort
+  trafficPolicy: PreferLocal
   selector:
     {{- include "spegel.selectorLabels" . | nindent 4 }}
   ports:

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -42,10 +42,6 @@ service:
     port: 5000
     # -- Node port to expose the registry via the service.
     nodePort: 30021
-    # -- Local host port to expose the registry.
-    hostPort: 30020
-    # -- If true adds topology aware hints annotation to node port service.
-    topologyAwareHintsEnabled: true
   router:
     # -- Port to expose the router via the service.
     port: 5001


### PR DESCRIPTION
This change moves to using a single service for all registry requests making use of the new traffic policy. This change will require Kubernetes 1.26 so it should not be merged until 1.25 is out of support.