### PR TITLE
Use namespace override to modify Spegel installed namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 
+- [#145](https://github.com/XenitAB/spegel/pull/145) Add new field to override Helm chart namespace.
+
 ### Changed
 
 ### Deprecated

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -63,6 +63,7 @@ spec:
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Image Pull Secrets |
 | nameOverride | string | `""` | Overrides the name of the chart. |
+| namespaceOverride | string | `""` | Overrides the namespace where spegel resources are installed. |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for pod assignment. |
 | podAnnotations | object | `{}` | Annotations to add to the pod. |
 | podSecurityContext | object | `{}` | Security context for the pod. |

--- a/charts/spegel/templates/_helpers.tpl
+++ b/charts/spegel/templates/_helpers.tpl
@@ -33,6 +33,8 @@ Defaults to the Release namespace unless the namespaceOverride is defined.
 {{- else }}
 {{- printf "%s" .Release.Namespace -}}
 {{- end }}
+{{- end }}
+
 
 {{/*
 Create chart name and version as used by the chart label.

--- a/charts/spegel/templates/_helpers.tpl
+++ b/charts/spegel/templates/_helpers.tpl
@@ -24,6 +24,17 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Creates the namespace for the chart. 
+Defaults to the Release namespace unless the namespaceOverride is defined.
+*/}}
+{{- define "spegel.namespace" -}}
+{{- if .Values.namespaceOverride }}
+{{- printf "%s" .Values.namespaceOverride -}}
+{{- else }}
+{{- printf "%s" .Release.Namespace -}}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "spegel.chart" -}}

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "spegel.fullname" . }}
+  namespace: {{ include "spegel.namespace" . }}
   labels:
     {{- include "spegel.labels" . | nindent 4 }}
 spec:

--- a/charts/spegel/templates/rbac.yaml
+++ b/charts/spegel/templates/rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "spegel.serviceAccountName" . }}
+  namespace: {{ include "spegel.namespace" . }}
   labels:
     {{- include "spegel.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
@@ -13,6 +14,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "spegel.fullname" . }}
+  namespace: {{ include "spegel.namespace" . }}
   labels:
     {{- include "spegel.labels" . | nindent 4 }}
 rules:
@@ -27,12 +29,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "spegel.fullname" . }}
+  namespace: {{ include "spegel.namespace" . }}
   labels:
     {{- include "spegel.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "spegel.fullname" . }}
+  namespace: {{ include "spegel.namespace" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "spegel.serviceAccountName" . }}
+    namespace: {{ include "spegel.namespace" . }}

--- a/charts/spegel/templates/service.yaml
+++ b/charts/spegel/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "spegel.fullname" . }}
+  namespace: {{ include "spegel.namespace" . }}
   labels:
     {{- include "spegel.labels" . | nindent 4 }}
 spec:
@@ -17,6 +18,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "spegel.fullname" . }}-registry
+  namespace: {{ include "spegel.namespace" . }}
   labels:
     {{- include "spegel.labels" . | nindent 4 }}
   {{- if .Values.service.registry.topologyAwareHintsEnabled }}

--- a/charts/spegel/templates/servicemonitor.yaml
+++ b/charts/spegel/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "spegel.fullname" . }}
+  namespace: {{ include "spegel.namespace" . }}
   labels:
     {{- include "spegel.labels" . | nindent 4 }}
 spec:

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -15,7 +15,7 @@ imagePullSecrets: []
 nameOverride: ""
 # -- Overrides the full name of the chart.
 fullnameOverride: ""
-# -- Overrides the namespace where spegel resources are installed
+# -- Overrides the namespace where spegel resources are installed.
 namespaceOverride: ""
 
 serviceAccount:

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -15,6 +15,8 @@ imagePullSecrets: []
 nameOverride: ""
 # -- Overrides the full name of the chart.
 fullnameOverride: ""
+# -- Overrides the namespace where spegel resources are installed
+namespaceOverride: ""
 
 serviceAccount:
   # -- Annotations to add to the service account


### PR DESCRIPTION
I would like to be able to use spegel as a subchart in my main helm chart, but I don't want to have all the spegel pods running in the main namespace since it will clutter it up. 

This way, we can chose to modify the namespace where all the spegel stuff goes. By default, it will just use the release namespace. 