### PR TITLE
Fix image parsing to allow only passing digest through image reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#152](https://github.com/XenitAB/spegel/pull/152) Fix image parsing to allow only passing digest through image reference.
+
 ### Security
 
 ## v0.0.9

--- a/internal/oci/image.go
+++ b/internal/oci/image.go
@@ -16,7 +16,7 @@ type Image struct {
 	Digest     digest.Digest
 }
 
-func NewImage(name, registry, repository, tag string, dgst digest.Digest) (Image, error) {
+func NewImage(registry, repository, tag string, dgst digest.Digest) (Image, error) {
 	if registry == "" {
 		return Image{}, fmt.Errorf("image needs to contain a registry")
 	}
@@ -86,11 +86,11 @@ func Parse(s string, extraDgst digest.Digest) (Image, error) {
 	if dgst == "" {
 		dgst = extraDgst
 	}
-	if dgst != extraDgst {
+	if extraDgst != "" && dgst != extraDgst {
 		return Image{}, fmt.Errorf("invalid digest set does not match parsed digest: %v %v", s, dgst)
 	}
 
-	img, err := NewImage(s, u.Host, repository, tag, dgst)
+	img, err := NewImage(u.Host, repository, tag, dgst)
 	if err != nil {
 		return Image{}, err
 	}

--- a/internal/oci/image_test.go
+++ b/internal/oci/image_test.go
@@ -12,6 +12,7 @@ func TestParseImage(t *testing.T) {
 	tests := []struct {
 		name               string
 		image              string
+		digestInImage      bool
 		expectedRepository string
 		expectedTag        string
 		expectedDigest     digest.Digest
@@ -19,6 +20,7 @@ func TestParseImage(t *testing.T) {
 		{
 			name:               "Latest tag",
 			image:              "library/ubuntu:latest",
+			digestInImage:      false,
 			expectedRepository: "library/ubuntu",
 			expectedTag:        "latest",
 			expectedDigest:     digest.Digest("sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda"),
@@ -26,6 +28,7 @@ func TestParseImage(t *testing.T) {
 		{
 			name:               "Only tag",
 			image:              "library/alpine:3.18.0",
+			digestInImage:      false,
 			expectedRepository: "library/alpine",
 			expectedTag:        "3.18.0",
 			expectedDigest:     digest.Digest("sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda"),
@@ -33,6 +36,7 @@ func TestParseImage(t *testing.T) {
 		{
 			name:               "Tag and digest",
 			image:              "jetstack/cert-manager-controller:3.18.0@sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda",
+			digestInImage:      true,
 			expectedRepository: "jetstack/cert-manager-controller",
 			expectedTag:        "3.18.0",
 			expectedDigest:     digest.Digest("sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda"),
@@ -40,6 +44,7 @@ func TestParseImage(t *testing.T) {
 		{
 			name:               "Only digest",
 			image:              "fluxcd/helm-controller@sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda",
+			digestInImage:      true,
 			expectedRepository: "fluxcd/helm-controller",
 			expectedTag:        "",
 			expectedDigest:     digest.Digest("sha256:c0669ef34cdc14332c0f1ab0c2c01acb91d96014b172f1a76f3a39e63d1f0bda"),
@@ -49,16 +54,27 @@ func TestParseImage(t *testing.T) {
 	for _, registry := range registries {
 		for _, tt := range tests {
 			t.Run(fmt.Sprintf("%s_%s", tt.name, registry), func(t *testing.T) {
-				img, err := Parse(fmt.Sprintf("%s/%s", registry, tt.image), digest.Digest(tt.expectedDigest))
-				require.NoError(t, err)
-				require.Equal(t, registry, img.Registry)
-				require.Equal(t, tt.expectedRepository, img.Repository)
-				require.Equal(t, tt.expectedTag, img.Tag)
-				require.Equal(t, tt.expectedDigest, img.Digest)
+				for _, extraDgst := range []string{tt.expectedDigest.String(), ""} {
+					img, err := Parse(fmt.Sprintf("%s/%s", registry, tt.image), digest.Digest(extraDgst))
+					if !tt.digestInImage && extraDgst == "" {
+						require.EqualError(t, err, "image needs to contain a digest")
+						continue
+					}
+					require.NoError(t, err)
+					require.Equal(t, registry, img.Registry)
+					require.Equal(t, tt.expectedRepository, img.Repository)
+					require.Equal(t, tt.expectedTag, img.Tag)
+					require.Equal(t, tt.expectedDigest, img.Digest)
+				}
 			})
 
 		}
 	}
+}
+
+func TestParseImageDigestDoesNotMatch(t *testing.T) {
+	_, err := Parse("quay.io/jetstack/cert-manager-webhook@sha256:13fd9eaadb4e491ef0e1d82de60cb199f5ad2ea5a3f8e0c19fdf31d91175b9cb", digest.Digest("sha256:ec4306b243d98cce7c3b1f994f2dae660059ef521b2b24588cfdc950bd816d4c"))
+	require.EqualError(t, err, "invalid digest set does not match parsed digest: quay.io/jetstack/cert-manager-webhook@sha256:13fd9eaadb4e491ef0e1d82de60cb199f5ad2ea5a3f8e0c19fdf31d91175b9cb sha256:13fd9eaadb4e491ef0e1d82de60cb199f5ad2ea5a3f8e0c19fdf31d91175b9cb")
 }
 
 func TestParseImageNoTagOrDigest(t *testing.T) {


### PR DESCRIPTION
Previously the extra digest had to passed to the parse function. This did not really cause any issues as it would always be set. Either way the behavior was not intended which is why it is being fixed.