### PR TITLE
Add option to disable resolving latest tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 
 - [#145](https://github.com/XenitAB/spegel/pull/145) Add new field to override Helm chart namespace.
+- [#153](https://github.com/XenitAB/spegel/pull/153) Add option to disable resolving latest tags.
 
 ### Changed
 

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -88,4 +88,5 @@ spec:
 | spegel.mirrorResolveRetries | int | `3` | Max ammount of mirrors to attempt. |
 | spegel.mirrorResolveTimeout | string | `"5s"` | Max duration spent finding a mirror. |
 | spegel.registries | list | `["https://docker.io","https://ghcr.io","https://quay.io","https://mcr.microsoft.com","https://public.ecr.aws","https://gcr.io","https://registry.k8s.io","https://k8s.gcr.io"]` | Registries for which mirror configuration will be created. |
+| spegel.resolveLatestTag | bool | `true` | When true latest tags will be resolved to digests. |
 | tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoExecute","operator":"Exists"},{"effect":"NoSchedule","operator":"Exists"}]` | Tolerations for pod assignment. |

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -80,6 +80,7 @@ spec:
           {{- end }}
           - --leader-election-namespace={{ .Release.Namespace }}
           - --leader-election-name={{ .Release.Namespace }}-leader-election
+          - --resolve-latest-tag={{ .Values.spegel.resolveLatestTag }}
         ports:
           - name: registry
             containerPort: {{ .Values.service.registry.port }}

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -122,3 +122,5 @@ spegel:
   containerdMirrorAdd: true
   # -- Path to Kubeconfig credentials, should only be set if Spegel is run in an environment without RBAC.
   kubeconfigPath: ""
+  # -- When true latest tags will be resolved to digests.
+  resolveLatestTag: true

--- a/internal/oci/image.go
+++ b/internal/oci/image.go
@@ -34,6 +34,10 @@ func NewImage(registry, repository, tag string, dgst digest.Digest) (Image, erro
 	}, nil
 }
 
+func (i Image) IsLatestTag() bool {
+	return i.Tag == "latest"
+}
+
 func (i Image) String() string {
 	tag := ""
 	if i.Tag != "" {

--- a/internal/oci/mock.go
+++ b/internal/oci/mock.go
@@ -1,0 +1,46 @@
+package oci
+
+import (
+	"context"
+	"io"
+
+	"github.com/opencontainers/go-digest"
+)
+
+type MockClient struct {
+	images []Image
+}
+
+func NewMockClient(images []Image) *MockClient {
+	return &MockClient{
+		images: images,
+	}
+}
+
+func (m *MockClient) Subscribe(ctx context.Context) (<-chan Image, <-chan error) {
+	return nil, nil
+}
+
+func (m *MockClient) ListImages(ctx context.Context) ([]Image, error) {
+	return m.images, nil
+}
+
+func (m *MockClient) GetImageDigests(ctx context.Context, img Image) ([]string, error) {
+	return []string{img.Digest.String()}, nil
+}
+
+func (m *MockClient) Resolve(ctx context.Context, ref string) (digest.Digest, error) {
+	return "", nil
+}
+
+func (m *MockClient) GetSize(ctx context.Context, dgst digest.Digest) (int64, error) {
+	return 0, nil
+}
+
+func (m *MockClient) WriteBlob(ctx context.Context, dst io.Writer, dgst digest.Digest) error {
+	return nil
+}
+
+func (m *MockClient) GetBlob(ctx context.Context, dgst digest.Digest) ([]byte, string, error) {
+	return nil, "", nil
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -60,7 +60,7 @@ func TestMirrorHandler(t *testing.T) {
 		"last-peer-working": {badSvr.URL, badSvr.URL, goodSvr.URL},
 	}
 	router := routing.NewMockRouter(resolver)
-	reg := NewRegistry(nil, router, 3, 5*time.Second)
+	reg := NewRegistry(nil, router, 3, 5*time.Second, false)
 
 	tests := []struct {
 		name            string

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,72 @@
+package state
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/xenitab/spegel/internal/oci"
+	"github.com/xenitab/spegel/internal/routing"
+)
+
+func TestBasic(t *testing.T) {
+	tests := []struct {
+		name             string
+		resolveLatestTag bool
+	}{
+		{
+			name:             "resolve latest",
+			resolveLatestTag: true,
+		},
+		{
+			name:             "do not resolve latest",
+			resolveLatestTag: false,
+		},
+	}
+
+	imgRefs := []string{
+		"docker.io/library/ubuntu:latest@sha256:b060fffe8e1561c9c3e6dea6db487b900100fc26830b9ea2ec966c151ab4c020",
+		"ghcr.io/xenitab/spegel:v0.0.9@sha256:fa32bd3bcd49a45a62cfc1b0fed6a0b63bf8af95db5bad7ec22865aee0a4b795",
+		"docker.io/library/alpine@sha256:25fad2a32ad1f6f510e528448ae1ec69a28ef81916a004d3629874104f8a7f70",
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imgs := []oci.Image{}
+			for _, imageStr := range imgRefs {
+				img, err := oci.Parse(imageStr, "")
+				require.NoError(t, err)
+				imgs = append(imgs, img)
+			}
+			ociClient := oci.NewMockClient(imgs)
+			router := routing.NewMockRouter(map[string][]string{})
+
+			ctx, cancel := context.WithCancel(context.TODO())
+			go func() {
+				time.Sleep(2 * time.Second)
+				cancel()
+			}()
+			err := Track(ctx, ociClient, router, tt.resolveLatestTag)
+			require.NoError(t, err)
+
+			for _, img := range imgs {
+				peers, ok := router.LookupKey(img.Digest.String())
+				require.True(t, ok)
+				require.Len(t, peers, 1)
+				tagName, ok := img.TagName()
+				if !ok {
+					continue
+				}
+				peers, ok = router.LookupKey(tagName)
+				if img.IsLatestTag() && !tt.resolveLatestTag {
+					require.False(t, ok)
+					continue
+				}
+				require.True(t, ok)
+				require.Len(t, peers, 1)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ type RegistryCmd struct {
 	KubeconfigPath          string        `arg:"--kubeconfig-path" help:"Path to the kubeconfig file."`
 	LeaderElectionNamespace string        `arg:"--leader-election-namespace" default:"spegel" help:"Kubernetes namespace to write leader election data."`
 	LeaderElectionName      string        `arg:"--leader-election-name" default:"spegel-leader-election" help:"Name of leader election."`
+	ResolveLatestTag        bool          `arg:"--resolve-latest-tag" default:"true" help:"When true latest tags will be resolved to digests."`
 }
 
 type Arguments struct {
@@ -139,10 +140,10 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 		return router.Close()
 	})
 	g.Go(func() error {
-		return state.Track(ctx, ociClient, router)
+		return state.Track(ctx, ociClient, router, args.ResolveLatestTag)
 	})
 
-	reg := registry.NewRegistry(ociClient, router, args.MirrorResolveRetries, args.MirrorResolveTimeout)
+	reg := registry.NewRegistry(ociClient, router, args.MirrorResolveRetries, args.MirrorResolveTimeout, args.ResolveLatestTag)
 	regSrv := reg.Server(args.RegistryAddr, log)
 	g.Go(func() error {
 		if err := regSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {


### PR DESCRIPTION
This is useful for those using latest tags with always as the image pull policy. In these cases the having Spegel resolve the digest for the latest tag is not optimal as it would never update. This will enable end users to continue with this strategy while using Spegel even if it is not an optimal way to update image versions.

Fixes #147 