### PR TITLE
Fix Containerd verify with check for empty configuration path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#152](https://github.com/XenitAB/spegel/pull/152) Fix image parsing to allow only passing digest through image reference.
+- [#158](https://github.com/XenitAB/spegel/pull/158) Fix Containerd verify with check for empty configuration path.
 
 ### Security
 

--- a/internal/oci/containerd.go
+++ b/internal/oci/containerd.go
@@ -78,8 +78,11 @@ func (c *Containerd) Verify(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if cfg.Registry.ConfigPath == "" {
+		return fmt.Errorf("Containerd registry config path needs to be set for mirror configuration to take effect")
+	}
 	if cfg.Registry.ConfigPath != c.registryConfigPath {
-		return fmt.Errorf("Containerd registry config path is %s but expected to be %s", cfg.Registry.ConfigPath, c.registryConfigPath)
+		return fmt.Errorf("Containerd registry config path is %s but needs to be %s for mirror configuration to take effect", cfg.Registry.ConfigPath, c.registryConfigPath)
 	}
 	return nil
 }


### PR DESCRIPTION
Having an empty string check is good to give a specific error message for that case.