### PR TITLE
Remove X-Spegel-Registry header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- [#160](https://github.com/XenitAB/spegel/pull/160) Remove X-Spegel-Registry header.
+
 ### Fixed
 
 - [#152](https://github.com/XenitAB/spegel/pull/152) Fix image parsing to allow only passing digest through image reference.

--- a/internal/header/header.go
+++ b/internal/header/header.go
@@ -1,29 +1,13 @@
 package header
 
 import (
-	"fmt"
 	"net/http"
-	"net/url"
 )
 
 const (
-	RegistryHeader = "X-Spegel-Registry"
 	MirrorHeader   = "X-Spegel-Mirror"
 	ExternalHeader = "X-Spegel-External"
 )
-
-// GetRemoteRegistry returns the target registry passed in the header.
-func GetRemoteRegistry(header http.Header) (string, error) {
-	registry := header.Get(RegistryHeader)
-	if registry == "" {
-		return "", fmt.Errorf("registry header cannot be empty")
-	}
-	registryUrl, err := url.Parse(registry)
-	if err != nil {
-		return "", fmt.Errorf("could not parse registry value: %w", err)
-	}
-	return registryUrl.Host, nil
-}
 
 // IsMirrorRequest returns true if mirror header is present.
 func IsMirrorRequest(header http.Header) bool {

--- a/internal/oci/containerd.go
+++ b/internal/oci/containerd.go
@@ -314,11 +314,10 @@ func hostsFileContent(registryURL url.URL, mirrorURLs []url.URL) string {
 	for i, mirrorURL := range mirrorURLs {
 		content = fmt.Sprintf(`%[1]s
 
-[host."%[3]s"]
+[host."%[2]s"]
   capabilities = ["pull", "resolve"]
-[host."%[3]s".header]
-  %[4]s = ["%[2]s"]
-  %[5]s = ["true"]`, content, registryURL.String(), mirrorURL.String(), header.RegistryHeader, header.MirrorHeader)
+[host."%[2]s".header]
+  %[3]s = ["true"]`, content, mirrorURL.String(), header.MirrorHeader)
 
 		// We assume first mirror registry is local. All others are external.
 		if i != 0 {

--- a/internal/oci/containerd_test.go
+++ b/internal/oci/containerd_test.go
@@ -236,7 +236,6 @@ func TestHostFileContent(t *testing.T) {
 [host."http://127.0.0.1:5000"]
   capabilities = ["pull", "resolve"]
 [host."http://127.0.0.1:5000".header]
-  X-Spegel-Registry = ["https://example.com"]
   X-Spegel-Mirror = ["true"]`,
 		},
 		{
@@ -248,13 +247,11 @@ func TestHostFileContent(t *testing.T) {
 [host."http://127.0.0.1:5000"]
   capabilities = ["pull", "resolve"]
 [host."http://127.0.0.1:5000".header]
-  X-Spegel-Registry = ["https://example.com"]
   X-Spegel-Mirror = ["true"]
 
 [host."http://127.0.0.1:5001"]
   capabilities = ["pull", "resolve"]
 [host."http://127.0.0.1:5001".header]
-  X-Spegel-Registry = ["https://example.com"]
   X-Spegel-Mirror = ["true"]
   X-Spegel-External = ["true"]`,
 		},
@@ -267,7 +264,6 @@ func TestHostFileContent(t *testing.T) {
 [host."http://127.0.0.1:5000"]
   capabilities = ["pull", "resolve"]
 [host."http://127.0.0.1:5000".header]
-  X-Spegel-Registry = ["https://docker.io"]
   X-Spegel-Mirror = ["true"]`,
 		},
 	}

--- a/internal/oci/distribution.go
+++ b/internal/oci/distribution.go
@@ -30,6 +30,9 @@ var (
 func ParsePathComponents(registry, path string) (string, digest.Digest, ReferenceType, error) {
 	comps := manifestRegexTag.FindStringSubmatch(path)
 	if len(comps) == 6 {
+		if registry == "" {
+			return "", "", "", fmt.Errorf("registry parameter needs to be set for tag references")
+		}
 		ref := fmt.Sprintf("%s/%s:%s", registry, comps[1], comps[5])
 		return ref, "", ReferenceTypeManifest, nil
 	}

--- a/internal/oci/distribution_test.go
+++ b/internal/oci/distribution_test.go
@@ -43,3 +43,13 @@ func TestParsePathComponents(t *testing.T) {
 		})
 	}
 }
+
+func TestParsePathComponentsInvalidPath(t *testing.T) {
+	_, _, _, err := ParsePathComponents("example.com", "/v2/xenitab/spegel/v0.0.1")
+	require.EqualError(t, err, "distribution path could not be parsed")
+}
+
+func TestParsePathComponentsMissingRegistry(t *testing.T) {
+	_, _, _, err := ParsePathComponents("", "/v2/xenitab/spegel/manifests/v0.0.1")
+	require.EqualError(t, err, "registry parameter needs to be set for tag references")
+}


### PR DESCRIPTION
The X-Spegel-Registry was added to the mirror configuration to allow resolving tags. This was done because the registry was not included in the path of the mirror request, and it was needed to resolve the image. At the time I thought this was the only solution.

It turns out that this is not the case and Containerd passees the registry as a query parameter in the request, for the explicit purpose of being used by image mirrors.
https://github.com/containerd/containerd/blob/40c85d6c09002e3207f807f5fc5a6a533fa87872/remotes/docker/resolver.go#L283-L285

This was implemented in https://github.com/containerd/containerd/pull/4413 about three years ago. I just did not see this during the initial design of Spegel.