### PR TITLE
Remove X-Spegel-Mirror header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - [#160](https://github.com/XenitAB/spegel/pull/160) Remove X-Spegel-Registry header.
+- [#161](https://github.com/XenitAB/spegel/pull/161) Remove X-Spegel-Mirror header.
 
 ### Fixed
 

--- a/internal/header/header.go
+++ b/internal/header/header.go
@@ -5,15 +5,8 @@ import (
 )
 
 const (
-	MirrorHeader   = "X-Spegel-Mirror"
 	ExternalHeader = "X-Spegel-External"
 )
-
-// IsMirrorRequest returns true if mirror header is present.
-func IsMirrorRequest(header http.Header) bool {
-	mirror := header.Get(MirrorHeader)
-	return mirror == "true"
-}
 
 // IsExternalRequest returns true if external header is present.
 func IsExternalRequest(header http.Header) bool {

--- a/internal/oci/containerd.go
+++ b/internal/oci/containerd.go
@@ -312,17 +312,16 @@ func hostsFileContent(registryURL url.URL, mirrorURLs []url.URL) string {
 	}
 	content := fmt.Sprintf(`server = "%s"`, server)
 	for i, mirrorURL := range mirrorURLs {
-		content = fmt.Sprintf(`%[1]s
+		content = fmt.Sprintf(`%s
 
-[host."%[2]s"]
-  capabilities = ["pull", "resolve"]
-[host."%[2]s".header]
-  %[3]s = ["true"]`, content, mirrorURL.String(), header.MirrorHeader)
+[host."%s"]
+  capabilities = ["pull", "resolve"]`, content, mirrorURL.String())
 
 		// We assume first mirror registry is local. All others are external.
 		if i != 0 {
 			content = fmt.Sprintf(`%s
-  %s = ["true"]`, content, header.ExternalHeader)
+[host."%s".header]
+  %s = ["true"]`, content, mirrorURL.String(), header.ExternalHeader)
 		}
 	}
 	return content

--- a/internal/oci/containerd_test.go
+++ b/internal/oci/containerd_test.go
@@ -234,9 +234,7 @@ func TestHostFileContent(t *testing.T) {
 			expectedContent: `server = "https://example.com"
 
 [host."http://127.0.0.1:5000"]
-  capabilities = ["pull", "resolve"]
-[host."http://127.0.0.1:5000".header]
-  X-Spegel-Mirror = ["true"]`,
+  capabilities = ["pull", "resolve"]`,
 		},
 		{
 			name:     "multiple mirrors",
@@ -246,13 +244,10 @@ func TestHostFileContent(t *testing.T) {
 
 [host."http://127.0.0.1:5000"]
   capabilities = ["pull", "resolve"]
-[host."http://127.0.0.1:5000".header]
-  X-Spegel-Mirror = ["true"]
 
 [host."http://127.0.0.1:5001"]
   capabilities = ["pull", "resolve"]
 [host."http://127.0.0.1:5001".header]
-  X-Spegel-Mirror = ["true"]
   X-Spegel-External = ["true"]`,
 		},
 		{
@@ -262,9 +257,7 @@ func TestHostFileContent(t *testing.T) {
 			expectedContent: `server = "https://registry-1.docker.io"
 
 [host."http://127.0.0.1:5000"]
-  capabilities = ["pull", "resolve"]
-[host."http://127.0.0.1:5000".header]
-  X-Spegel-Mirror = ["true"]`,
+  capabilities = ["pull", "resolve"]`,
 		},
 	}
 


### PR DESCRIPTION
Requiring the X-Spegel-Mirror header in a image pull HTTP requests increased complexity, as it had to be set in the mirror configuration. It's purpose is to determine if a request should be mirrored or served. It is a lot simpler for Spegel to write a similar header to the request when mirroring the request. It has the same effect but simplifies the mirror configuration.