### PR TITLE
Remove unneeded namespace in role binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#152](https://github.com/XenitAB/spegel/pull/152) Fix image parsing to allow only passing digest through image reference.
 - [#158](https://github.com/XenitAB/spegel/pull/158) Fix Containerd verify with check for empty configuration path.
+- [#163](https://github.com/XenitAB/spegel/pull/163) Remove unneeded namespace in role binding.
 
 ### Security
 

--- a/charts/spegel/templates/rbac.yaml
+++ b/charts/spegel/templates/rbac.yaml
@@ -36,7 +36,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "spegel.fullname" . }}
-  namespace: {{ include "spegel.namespace" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "spegel.serviceAccountName" . }}


### PR DESCRIPTION
Change in #145 added a namespace field to a role binding, which is not actually possible. This change removes that setting.