### PR TITLE
Backup existing Containerd mirror configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 
+- [#170](https://github.com/XenitAB/spegel/pull/170) Backup existing Containerd mirror configuration.
+
 ### Changed
 
 ### Deprecated

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ e2e: docker-build
 	echo $$KIND_KUBECONFIG
 	kind create cluster --kubeconfig $$KIND_KUBECONFIG --config ./e2e/kind-config.yaml
 
+	# Write existing configuration to test backup.
+	HOSTS_TOML='server = "https://docker.io"\n\n[host."https://registry-1.docker.io"]\n  capabilities = ["push"]'
+	docker exec kind-worker2 bash -c "mkdir -p /etc/containerd/certs.d/docker.io; echo -e '$$HOSTS_TOML' > /etc/containerd/certs.d/docker.io/hosts.toml"
+
 	# Pull images onto single node which will never run workload.
 	docker exec kind-worker ctr -n k8s.io image pull docker.io/library/nginx:1.23.0
 	docker exec kind-worker ctr -n k8s.io image pull docker.io/library/nginx@sha256:b3a676a9145dc005062d5e79b92d90574fb3bf2396f4913dc1732f9065f55c4b
@@ -36,12 +40,20 @@ e2e: docker-build
 		docker exec $$NODE ctr -n k8s.io image tag ${IMG} ghcr.io/xenitab/spegel@$${DIGEST}
 	done
 	kubectl --kubeconfig $$KIND_KUBECONFIG create namespace spegel
-	helm --kubeconfig $$KIND_KUBECONFIG upgrade --install --namespace="spegel" spegel ./charts/spegel --set "image.pullPolicy=Never" --set "image.digest=$${DIGEST}" --set "nodeSelector.spegel=schedule"
+	helm --kubeconfig $$KIND_KUBECONFIG upgrade --wait --install --namespace="spegel" spegel ./charts/spegel --set "image.pullPolicy=Never" --set "image.digest=$${DIGEST}" --set "nodeSelector.spegel=schedule"
 	kubectl --kubeconfig $$KIND_KUBECONFIG --namespace spegel rollout status daemonset spegel --timeout 60s
 	POD_COUNT=$$(kubectl --kubeconfig $$KIND_KUBECONFIG --namespace spegel get pods --no-headers | wc -l)
 	if [[ $$POD_COUNT != "5" ]]
 	then
 		echo "Spegel should have 5 Pods running."
+		exit 1
+	fi
+
+	# Verify that configuration has been backed up.
+	BACKUP_HOSTS_TOML=$$(docker exec kind-worker2 cat /etc/containerd/certs.d/_backup/docker.io/hosts.toml)
+	if [ $$BACKUP_HOSTS_TOML != $$HOSTS_TOML ]
+	then
+		echo "Spegel has not properly backed up existing configuration."
 		exit 1
 	fi
 


### PR DESCRIPTION
Currently the mirror configuration write is append only. Meaning that registries are only added, never removed. Some Kubernetes deployments may already contain Containerd mirror configuration. On top of that it turns out that removing registries will not remove the configuration from nodes that have already been configured.

To solve both issues this feature will backup existing configuration on first startup, and then remove all other files. If the backup directory already exists it only remove all other existing configuration files before writing the new configuration.

This also enables us to solve #67 in the future when we figure out how to detect an uninstall properly.