### PR TITLE
Modify error handling in state tracking to avoid exiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#174](https://github.com/XenitAB/spegel/pull/174) Modify error handling in state tracking to avoid exiting.
+
 ### Deprecated
 
 ### Removed

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -48,8 +48,7 @@ func TestBasic(t *testing.T) {
 				time.Sleep(2 * time.Second)
 				cancel()
 			}()
-			err := Track(ctx, ociClient, router, tt.resolveLatestTag)
-			require.NoError(t, err)
+			Track(ctx, ociClient, router, tt.resolveLatestTag)
 
 			for _, img := range imgs {
 				peers, ok := router.LookupKey(img.Digest.String())

--- a/main.go
+++ b/main.go
@@ -147,7 +147,8 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 		return router.Close()
 	})
 	g.Go(func() error {
-		return state.Track(ctx, ociClient, router, args.ResolveLatestTag)
+		state.Track(ctx, ociClient, router, args.ResolveLatestTag)
+		return nil
 	})
 
 	reg := registry.NewRegistry(ociClient, router, args.LocalAddr, args.MirrorResolveRetries, args.MirrorResolveTimeout, args.ResolveLatestTag)


### PR DESCRIPTION
Exiting Spegel when an error occurs in the state tracking is not really a good idea. The error may be caused by an invalid layer which has nothing to do with Spegel. It is a lot better to log the error rather than exiting on the first error.

This helps decrease the impact of errors like the one in #172. 