### PR TITLE
Add lscr.io as default registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 
+- [#182](https://github.com/XenitAB/spegel/pull/182) Add lscr.io as default registry.
+
 ### Changed
 
 ### Deprecated

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -87,7 +87,7 @@ spec:
 | spegel.kubeconfigPath | string | `""` | Path to Kubeconfig credentials, should only be set if Spegel is run in an environment without RBAC. |
 | spegel.mirrorResolveRetries | int | `3` | Max ammount of mirrors to attempt. |
 | spegel.mirrorResolveTimeout | string | `"5s"` | Max duration spent finding a mirror. |
-| spegel.registries | list | `["https://docker.io","https://ghcr.io","https://quay.io","https://mcr.microsoft.com","https://public.ecr.aws","https://gcr.io","https://registry.k8s.io","https://k8s.gcr.io"]` | Registries for which mirror configuration will be created. |
+| spegel.registries | list | `["https://docker.io","https://ghcr.io","https://quay.io","https://mcr.microsoft.com","https://public.ecr.aws","https://gcr.io","https://registry.k8s.io","https://k8s.gcr.io","https://lscr.io"]` | Registries for which mirror configuration will be created. |
 | spegel.resolveLatestTag | bool | `true` | When true latest tags will be resolved to digests. |
 | spegel.resolveTags | bool | `true` | When true Spegel will resolve tags to digests. |
 | tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoExecute","operator":"Exists"},{"effect":"NoSchedule","operator":"Exists"}]` | Tolerations for pod assignment. |

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -106,6 +106,7 @@ spegel:
     - https://gcr.io
     - https://registry.k8s.io
     - https://k8s.gcr.io
+    - https://lscr.io
   # -- Extra target mirror registries other than Spegel.
   extraMirrorRegistries: []
   # -- Max ammount of mirrors to attempt.


### PR DESCRIPTION
I observed the use of the registry `lscr.io` in a blog post, which is a public registry I did not know about.
https://medium.com/linux-shots/speed-up-pod-startup-by-re-using-image-layers-from-other-nodes-with-spegel-817f88d40a92

It turns out that it is a pull through registry mirror, that also collects some usage metrics. We might as well add it to the default list even if there may not exist too many users out there.
https://www.linuxserver.io/blog/wrap-up-warm-for-the-winter