### PR TITLE
Fix Containerd config path verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#181](https://github.com/XenitAB/spegel/pull/181) Fix mirroring images using index files without a media type.
+- [#191](https://github.com/XenitAB/spegel/pull/191) Fix Containerd config path verification.
 
 ### Security
 


### PR DESCRIPTION
The first implementation that verified Containerd config path was built with the assumption that the path was a singular path. It is however a list of path with a OS specific separator. This change fixes the verification and adds some additional testing for the verification.

Fixes #190 