### PR TITLE
fix spegel namespace in daemonset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 
+- [#195](https://github.com/XenitAB/spegel/pull/195) Fix daemonset argument namespace to use helper-defined namespace value.
+
 ### Changed
 
 ### Deprecated

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -80,8 +80,8 @@ spec:
           {{- with .Values.spegel.kubeconfigPath }}
           - --kubeconfig-path={{ . }}
           {{- end }}
-          - --leader-election-namespace={{ .Release.Namespace }}
-          - --leader-election-name={{ .Release.Namespace }}-leader-election
+          - --leader-election-namespace={{ include "spegel.namespace" . }}
+          - --leader-election-name={{ include "spegel.namespace" . }}-leader-election
           - --resolve-latest-tag={{ .Values.spegel.resolveLatestTag }}
           - --local-addr=127.0.0.1:{{ .Values.service.registry.hostPort }}
         ports:


### PR DESCRIPTION
Added more uses of the helper `spegel.namespace` for all namespace related injection, otherwise it will break when installing it in a different namespace as a subchart. 