### PR TITLE
Use release name instead of namespace for name of leader election configmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#164](https://github.com/XenitAB/spegel/pull/164) Update Go to 1.21.
 - [#211](https://github.com/XenitAB/spegel/pull/211) Replace factory with adress filter to remove loopback addresses.
+- [#219](https://github.com/XenitAB/spegel/pull/219) Use release name instead of namespace for name of leader election configmap.
 
 ### Deprecated
 

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -81,7 +81,7 @@ spec:
           - --kubeconfig-path={{ . }}
           {{- end }}
           - --leader-election-namespace={{ include "spegel.namespace" . }}
-          - --leader-election-name={{ include "spegel.namespace" . }}-leader-election
+          - --leader-election-name={{ .Release.Name }}-leader-election
           - --resolve-latest-tag={{ .Values.spegel.resolveLatestTag }}
           - --local-addr=127.0.0.1:{{ .Values.service.registry.hostPort }}
         ports:


### PR DESCRIPTION
Using the release name rather than the namespace is better for those installing in a namespace other than Spegel.

Fixes #218 