### PR TITLE
Propagate closing channel before resolve timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#241](https://github.com/XenitAB/spegel/pull/241) Fix missing return on resolve error.
+- [#223](https://github.com/XenitAB/spegel/pull/223) Propagate closing channel before resolve timeout.
 
 ### Security
 

--- a/internal/routing/p2p.go
+++ b/internal/routing/p2p.go
@@ -147,6 +147,7 @@ func (r *P2PRouter) Resolve(ctx context.Context, key string, allowSelf bool, cou
 			// Combine peer with registry port to create mirror endpoint.
 			peerCh <- fmt.Sprintf("http://%s:%s", v, r.registryPort)
 		}
+		close(peerCh)
 	}()
 	return peerCh, nil
 }


### PR DESCRIPTION
This change aims to address timeouts that occur when a key cannot be resolved at all. Currently every request that can't be resolved will be forced to wait the full timeout. A better solution is to exit early if libp2p closes the channel.
