### PR TITLE
Verify discard unpacked layers setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 
+- [#237](https://github.com/XenitAB/spegel/pull/237) Verify discard unpacked layers setting.
+
 ### Changed
 
 ### Deprecated

--- a/internal/oci/containerd.go
+++ b/internal/oci/containerd.go
@@ -86,10 +86,18 @@ func verifyStatusResponse(resp *runtimeapi.StatusResponse, configPath string) er
 		Registry struct {
 			ConfigPath string `json:"configPath"`
 		} `json:"registry"`
+		Containerd struct {
+			Runtimes struct {
+				DiscardUnpackedLayers bool `json:"discardUnpackedLayers"`
+			} `json:"runtimes"`
+		} `json:"containerd"`
 	}{}
 	err := json.Unmarshal([]byte(str), cfg)
 	if err != nil {
 		return err
+	}
+	if cfg.Containerd.Runtimes.DiscardUnpackedLayers {
+		return fmt.Errorf("Containerd discard unpacked layers cannot be enabled")
 	}
 	if cfg.Registry.ConfigPath == "" {
 		return fmt.Errorf("Containerd registry config path needs to be set for mirror configuration to take effect")


### PR DESCRIPTION
It became clear in #217 that Spegel works very poorly if Containerd discard unpacked layers is enabled. When it is enabled  any layer that is not required to run the container will be discarded. It defeats the purpose of Spegel which needs these layers present to distribute.

By default this is disabled. However it was recently enabled in EKS by default causing issues for some users.
https://github.com/awslabs/amazon-eks-ami/pull/1360

This change implements a check for this setting and exits if it is enabled. This will hopefully inform users in the future if the setting has been enabled.