### PR TITLE
Set Go image version with digest in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#262](https://github.com/XenitAB/spegel/pull/262) Enable misspell linter and fix spelling mistakes.
 - [#263](https://github.com/XenitAB/spegel/pull/263) Enable testifylint linter and fix errors.
+- [#269](https://github.com/XenitAB/spegel/pull/269) Set Go image version with digest in Dockerfile.
 
 ### Security
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as builder
+FROM golang:1.21.4@sha256:337543447173c2238c78d4851456760dcc57c1dfa8c3bcd94cbee8b0f7b32ad0 as builder
 RUN mkdir /build
 WORKDIR /build
 COPY go.mod go.mod


### PR DESCRIPTION
This will make sure that we are building with the correct minor version of Go.