### PR TITLE
Fix Golang image digest to use manifest list instead of AMD64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#276](https://github.com/XenitAB/spegel/pull/276) Fix Golang image digest to use manifest list instead of AMD64.
+
 ### Security
 
 ## v0.0.15

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.4@sha256:337543447173c2238c78d4851456760dcc57c1dfa8c3bcd94cbee8b0f7b32ad0 as builder
+FROM golang:1.21.4@sha256:9baee0edab4139ae9b108fffabb8e2e98a67f0b259fd25283c2a084bd74fea0d as builder
 RUN mkdir /build
 WORKDIR /build
 COPY go.mod go.mod


### PR DESCRIPTION
Fixes #275 