### PR TITLE
Fix broken default value for additional mirror registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#279](https://github.com/XenitAB/spegel/pull/279) Fix broken default value for additional mirror registries.
+
 ### Security
 
 ## v0.0.16

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -82,11 +82,11 @@ spec:
 | serviceMonitor.interval | string | `"60s"` | Prometheus scrape interval. |
 | serviceMonitor.labels | object | `{}` | Service monitor specific labels for prometheus to discover servicemonitor. |
 | serviceMonitor.scrapeTimeout | string | `"30s"` | Prometheus scrape interval timeout. |
+| spegel.additionalMirrorRegistries | list | `[]` | Additional target mirror registries other than Spegel. |
 | spegel.containerdMirrorAdd | bool | `true` | If true Spegel will add mirror configuration to the node. |
 | spegel.containerdNamespace | string | `"k8s.io"` | Containerd namespace where images are stored. |
 | spegel.containerdRegistryConfigPath | string | `"/etc/containerd/certs.d"` | Path to Containerd mirror configuration. |
 | spegel.containerdSock | string | `"/run/containerd/containerd.sock"` | Path to Containerd socket. |
-| spegel.extraMirrorRegistries | list | `[]` | Extra target mirror registries other than Spegel. |
 | spegel.kubeconfigPath | string | `""` | Path to Kubeconfig credentials, should only be set if Spegel is run in an environment without RBAC. |
 | spegel.mirrorResolveRetries | int | `3` | Max ammount of mirrors to attempt. |
 | spegel.mirrorResolveTimeout | string | `"5s"` | Max duration spent finding a mirror. |

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -113,8 +113,8 @@ spegel:
     - https://registry.k8s.io
     - https://k8s.gcr.io
     - https://lscr.io
-  # -- Extra target mirror registries other than Spegel.
-  extraMirrorRegistries: []
+  # -- Additional target mirror registries other than Spegel.
+  additionalMirrorRegistries: []
   # -- Max ammount of mirrors to attempt.
   mirrorResolveRetries: 3
   # -- Max duration spent finding a mirror.


### PR DESCRIPTION
For some reason the value `extraMirrorRegistries` in the values file does not match the referenced `additionalMirrorRegistries` in the daemonset template. This change fixes the values file to use `additionalMirrorRegistries` instead.