### PR TITLE
Fix support for ipv6

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cni: [iptables, ipvs]
+        cni: [iptables, iptables-ipv6, ipvs]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#279](https://github.com/XenitAB/spegel/pull/279) Fix broken default value for additional mirror registries.
+- [#284](https://github.com/XenitAB/spegel/pull/284) Fix Spegel support for ipv6.
 
 ### Security
 

--- a/charts/spegel/templates/daemonset.yaml
+++ b/charts/spegel/templates/daemonset.yaml
@@ -97,7 +97,6 @@ spec:
         ports:
           - name: registry
             containerPort: {{ .Values.service.registry.port }}
-            hostIP: "127.0.0.1"    
             hostPort: {{ .Values.service.registry.hostPort }}
             protocol: TCP
           - name: router

--- a/internal/routing/p2p_test.go
+++ b/internal/routing/p2p_test.go
@@ -1,0 +1,79 @@
+package routing
+
+import (
+	"testing"
+
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListenMultiaddrs(t *testing.T) {
+	tests := []struct {
+		name     string
+		addr     string
+		expected []string
+	}{
+		{
+			name:     "listen address type not specified",
+			addr:     ":9090",
+			expected: []string{"/ip6/::/tcp/9090", "/ip4/0.0.0.0/tcp/9090"},
+		},
+		{
+			name:     "ipv4 only",
+			addr:     "0.0.0.0:9090",
+			expected: []string{"/ip4/0.0.0.0/tcp/9090"},
+		},
+		{
+			name:     "ipv6 only",
+			addr:     "[::]:9090",
+			expected: []string{"/ip6/::/tcp/9090"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			multiAddrs, err := listenMultiaddrs(tt.addr)
+			require.NoError(t, err)
+			require.Equal(t, len(tt.expected), len(multiAddrs))
+			for i, e := range tt.expected {
+				require.Equal(t, e, multiAddrs[i].String())
+			}
+		})
+	}
+}
+
+func TestIPInMultiaddr(t *testing.T) {
+	tests := []struct {
+		name     string
+		ma       string
+		expected string
+	}{
+		{
+			name:     "ipv4",
+			ma:       "/ip4/10.244.1.2/tcp/5001",
+			expected: "10.244.1.2",
+		},
+		{
+			name:     "ipv6",
+			ma:       "/ip6/0:0:0:0:0:ffff:0af4:0102/tcp/5001",
+			expected: "::ffff:10.244.1.2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			multiAddr, err := ma.NewMultiaddr(tt.ma)
+			require.NoError(t, err)
+			v, err := ipInMultiaddr(multiAddr)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, v)
+		})
+	}
+}
+
+func TestIsIp6(t *testing.T) {
+	m, err := ma.NewMultiaddr("/ip6/::")
+	require.NoError(t, err)
+	require.True(t, isIp6(m))
+	m, err = ma.NewMultiaddr("/ip4/0.0.0.0")
+	require.NoError(t, err)
+	require.False(t, isIp6(m))
+}

--- a/test/e2e/kind-config-iptables-ipv6.yaml
+++ b/test/e2e/kind-config-iptables-ipv6.yaml
@@ -1,0 +1,36 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+networking:
+  ipFamily: ipv6
+  kubeProxyMode: "iptables"
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"
+  # Discarding unpacked layers causes them to be removed, which defeats the purpose of a local cache.
+  # Additioanlly nodes will report having layers which no long exist.
+  # This is by default false in containerd.
+  [plugins."io.containerd.grpc.v1.cri".containerd]
+    discard_unpacked_layers = false
+  # This is just to make sure that images are not shared between namespaces.
+  [plugins."io.containerd.metadata.v1.bolt"]
+    content_sharing_policy = "isolated"
+nodes:
+  - role: control-plane
+    labels:
+      spegel: schedule
+  - role: worker
+    labels:
+      spegel: schedule
+  - role: worker
+    labels:
+      spegel: schedule
+      test: true
+  - role: worker
+    labels:
+      spegel: schedule
+      test: true
+  - role: worker
+    labels:
+      spegel: schedule
+      test: true


### PR DESCRIPTION
An important detail with this implementation is that it will prioritize IPV6 if Spegel is run in a dualstack cluster.

Part of enabling embedding Spegel in k3s.
https://github.com/k3s-io/k3s/pull/8977