### PR TITLE
Realign the structs in attempt to minimise memory usage.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,3 +9,4 @@ linters:
     - unused
     - misspell
     - testifylint
+    - fieldalignment

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,4 +9,7 @@ linters:
     - unused
     - misspell
     - testifylint
-    - fieldalignment
+linters-settings:
+  govet:
+    enable:
+      - fieldalignment

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -38,10 +38,10 @@ var mirrorRequestsTotal = promauto.NewCounterVec(
 type Registry struct {
 	ociClient        oci.Client
 	router           routing.Router
+	localAddr        string
 	resolveRetries   int
 	resolveTimeout   time.Duration
 	resolveLatestTag bool
-	localAddr        string
 }
 
 func NewRegistry(ociClient oci.Client, router routing.Router, localAddr string, resolveRetries int, resolveTimeout time.Duration, resolveLatestTag bool) *Registry {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -63,11 +63,11 @@ func TestMirrorHandler(t *testing.T) {
 	reg := NewRegistry(nil, router, "", 3, 5*time.Second, false)
 
 	tests := []struct {
+		expectedHeaders map[string][]string
 		name            string
 		key             string
-		expectedStatus  int
 		expectedBody    string
-		expectedHeaders map[string][]string
+		expectedStatus  int
 	}{
 		{
 			name:            "request should timeout when no peers exists",

--- a/internal/routing/bootstrap.go
+++ b/internal/routing/bootstrap.go
@@ -18,12 +18,12 @@ type Bootstrapper interface {
 }
 
 type KubernetesBootstrapper struct {
-	leaderElectionNamespace string
-	leaderElectioName       string
 	cs                      kubernetes.Interface
 	initCh                  chan interface{}
-	mx                      sync.RWMutex
+	leaderElectionNamespace string
+	leaderElectioName       string
 	id                      string
+	mx                      sync.RWMutex
 }
 
 func NewKubernetesBootstrapper(cs kubernetes.Interface, namespace, name string) Bootstrapper {

--- a/internal/routing/mock.go
+++ b/internal/routing/mock.go
@@ -6,8 +6,8 @@ import (
 )
 
 type MockRouter struct {
-	mx       sync.RWMutex
 	resolver map[string][]string
+	mx       sync.RWMutex
 }
 
 func NewMockRouter(resolver map[string][]string) *MockRouter {

--- a/main.go
+++ b/main.go
@@ -36,20 +36,20 @@ type ConfigurationCmd struct {
 }
 
 type RegistryCmd struct {
-	RegistryAddr                 string        `arg:"--registry-addr,required" help:"address to server image registry."`
-	RouterAddr                   string        `arg:"--router-addr,required" help:"address to serve router."`
+	KubeconfigPath               string        `arg:"--kubeconfig-path" help:"Path to the kubeconfig file."`
+	ContainerdRegistryConfigPath string        `arg:"--containerd-registry-config-path" default:"/etc/containerd/certs.d" help:"Directory where mirror configuration is written."`
 	MetricsAddr                  string        `arg:"--metrics-addr,required" help:"address to serve metrics."`
-	Registries                   []url.URL     `arg:"--registries,required" help:"registries that are configured to be mirrored."`
+	LocalAddr                    string        `arg:"--local-addr,required" help:"Address that the local Spegel instance will be reached at."`
 	ContainerdSock               string        `arg:"--containerd-sock" default:"/run/containerd/containerd.sock" help:"Endpoint of containerd service."`
 	ContainerdNamespace          string        `arg:"--containerd-namespace" default:"k8s.io" help:"Containerd namespace to fetch images from."`
-	ContainerdRegistryConfigPath string        `arg:"--containerd-registry-config-path" default:"/etc/containerd/certs.d" help:"Directory where mirror configuration is written."`
-	MirrorResolveRetries         int           `arg:"--mirror-resolve-retries" default:"3" help:"Max amount of mirrors to attempt."`
-	MirrorResolveTimeout         time.Duration `arg:"--mirror-resolve-timeout" default:"5s" help:"Max duration spent finding a mirror."`
-	KubeconfigPath               string        `arg:"--kubeconfig-path" help:"Path to the kubeconfig file."`
-	LeaderElectionNamespace      string        `arg:"--leader-election-namespace" default:"spegel" help:"Kubernetes namespace to write leader election data."`
+	RouterAddr                   string        `arg:"--router-addr,required" help:"address to serve router."`
 	LeaderElectionName           string        `arg:"--leader-election-name" default:"spegel-leader-election" help:"Name of leader election."`
+	LeaderElectionNamespace      string        `arg:"--leader-election-namespace" default:"spegel" help:"Kubernetes namespace to write leader election data."`
+	RegistryAddr                 string        `arg:"--registry-addr,required" help:"address to server image registry."`
+	Registries                   []url.URL     `arg:"--registries,required" help:"registries that are configured to be mirrored."`
+	MirrorResolveTimeout         time.Duration `arg:"--mirror-resolve-timeout" default:"5s" help:"Max duration spent finding a mirror."`
+	MirrorResolveRetries         int           `arg:"--mirror-resolve-retries" default:"3" help:"Max amount of mirrors to attempt."`
 	ResolveLatestTag             bool          `arg:"--resolve-latest-tag" default:"true" help:"When true latest tags will be resolved to digests."`
-	LocalAddr                    string        `arg:"--local-addr,required" help:"Address that the local Spegel instance will be reached at."`
 }
 
 type Arguments struct {

--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -369,8 +369,8 @@ func createFilters(registries []url.URL) (string, string) {
 }
 
 type hostFile struct {
-	Server      string                `toml:"server"`
 	HostConfigs map[string]hostConfig `toml:"host"`
+	Server      string                `toml:"server"`
 }
 
 type hostConfig struct {

--- a/pkg/oci/containerd_test.go
+++ b/pkg/oci/containerd_test.go
@@ -24,9 +24,9 @@ func TestVerifyStatusResponse(t *testing.T) {
 	tests := []struct {
 		name                  string
 		configPath            string
-		discardUnpackedLayers bool
 		requiredConfigPath    string
 		expectedErrMsg        string
+		discardUnpackedLayers bool
 	}{
 		{
 			name:               "empty config path",
@@ -248,9 +248,9 @@ func TestGetImageDigestsNoPlatform(t *testing.T) {
 func TestCreateFilter(t *testing.T) {
 	tests := []struct {
 		name                string
-		registries          []string
 		expectedListFilter  string
 		expectedEventFilter string
+		registries          []string
 	}{
 		{
 			name:                "only registries",
@@ -279,13 +279,13 @@ func TestMirrorConfiguration(t *testing.T) {
 	registryConfigPath := "/etc/containerd/certs.d"
 
 	tests := []struct {
-		name                string
-		resolveTags         bool
-		registries          []url.URL
-		mirrors             []url.URL
-		createConfigPathDir bool
 		existingFiles       map[string]string
 		expectedFiles       map[string]string
+		name                string
+		registries          []url.URL
+		mirrors             []url.URL
+		resolveTags         bool
+		createConfigPathDir bool
 	}{
 		{
 			name:        "multiple mirros",

--- a/pkg/oci/image_test.go
+++ b/pkg/oci/image_test.go
@@ -12,10 +12,10 @@ func TestParseImage(t *testing.T) {
 	tests := []struct {
 		name               string
 		image              string
-		digestInImage      bool
 		expectedRepository string
 		expectedTag        string
 		expectedDigest     digest.Digest
+		digestInImage      bool
 	}{
 		{
 			name:               "Latest tag",


### PR DESCRIPTION
Results:
```
spegel/internal/routing/bootstrap.go:20:29: struct with 88 pointer bytes could be 64
spegel/internal/routing/mock.go:8:17: struct with 32 pointer bytes could be 8
spegel/pkg/oci/containerd.go:371:15: struct with 24 pointer bytes could be 16
spegel/internal/registry/registry.go:38:15: struct with 64 pointer bytes could be 40
spegel/main.go:38:18: struct with 200 pointer bytes could be 168
spegel/internal/registry/registry_test.go:65:13: struct with 64 pointer bytes could be 48
spegel/pkg/oci/containerd_test.go:24:13: struct with 64 pointer bytes could be 56
spegel/pkg/oci/containerd_test.go:249:13: struct with 64 pointer bytes could be 56
spegel/pkg/oci/containerd_test.go:281:13: struct of size 96 could be 88
spegel/pkg/oci/image_test.go:12:13: struct with 80 pointer bytes could be 72
```