### PR TITLE
Refactor registry mirror url parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#318](https://github.com/XenitAB/spegel/pull/318) Refactor registry mirror url parsing.
+
 ### Deprecated
 
 ### Removed

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -200,11 +201,9 @@ func (r *Registry) handleMirror(c *gin.Context, key string) {
 			// If proxy fails no response is written and it is tried again against a different mirror.
 			// If the response writer has been written to it means that the request was properly proxied.
 			succeeded := false
-			u, err := url.Parse(mirror)
-			if err != nil {
-				//nolint:errcheck // ignore
-				c.AbortWithError(http.StatusInternalServerError, err)
-				return
+			u := &url.URL{
+				Scheme: c.Request.URL.Scheme,
+				Host:   net.JoinHostPort(mirror, c.Request.URL.Port()),
 			}
 			proxy := httputil.NewSingleHostReverseProxy(u)
 			proxy.ErrorHandler = func(http.ResponseWriter, *http.Request, error) {}

--- a/internal/routing/p2p.go
+++ b/internal/routing/p2p.go
@@ -21,14 +21,13 @@ import (
 )
 
 type P2PRouter struct {
-	b            Bootstrapper
-	host         host.Host
-	kdht         *dht.IpfsDHT
-	rd           *routing.RoutingDiscovery
-	registryPort string
+	b    Bootstrapper
+	host host.Host
+	kdht *dht.IpfsDHT
+	rd   *routing.RoutingDiscovery
 }
 
-func NewP2PRouter(ctx context.Context, addr string, b Bootstrapper, registryPort string) (Router, error) {
+func NewP2PRouter(ctx context.Context, addr string, b Bootstrapper) (Router, error) {
 	log := logr.FromContextOrDiscard(ctx).WithName("p2p")
 
 	multiAddrs, err := listenMultiaddrs(addr)
@@ -104,11 +103,10 @@ func NewP2PRouter(ctx context.Context, addr string, b Bootstrapper, registryPort
 	rd := routing.NewRoutingDiscovery(kdht)
 
 	return &P2PRouter{
-		b:            b,
-		host:         host,
-		kdht:         kdht,
-		rd:           rd,
-		registryPort: registryPort,
+		b:    b,
+		host: host,
+		kdht: kdht,
+		rd:   rd,
 	}, nil
 }
 
@@ -156,10 +154,7 @@ func (r *P2PRouter) Resolve(ctx context.Context, key string, allowSelf bool, cou
 				log.Error(err, "could not get IP address")
 				continue
 			}
-			// Combine peer with registry port to create mirror endpoint.
-			registryEnpoint := net.JoinHostPort(host, r.registryPort)
-			// TODO: Fix support for https scheme
-			peerCh <- fmt.Sprintf("http://%s", registryEnpoint)
+			peerCh <- host
 		}
 		close(peerCh)
 	}()

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -135,12 +134,8 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 		return metricsSrv.Shutdown(shutdownCtx)
 	})
 
-	_, registryPort, err := net.SplitHostPort(args.RegistryAddr)
-	if err != nil {
-		return err
-	}
 	bootstrapper := routing.NewKubernetesBootstrapper(cs, args.LeaderElectionNamespace, args.LeaderElectionName)
-	router, err := routing.NewP2PRouter(ctx, args.RouterAddr, bootstrapper, registryPort)
+	router, err := routing.NewP2PRouter(ctx, args.RouterAddr, bootstrapper)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change aims to simplify the method of figuring out scheme and port for mirror by basing it on the incoming request url.