### PR TITLE
Refactor bootstrap to exit on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#319](https://github.com/XenitAB/spegel/pull/319) Move metrics definitions to separate package.
 - [#322](https://github.com/XenitAB/spegel/pull/322) Refactor type of router resolve.
+- [#325](https://github.com/XenitAB/spegel/pull/325) Refactor bootstrap to exit on error.
 
 ### Deprecated
 


### PR DESCRIPTION
This resolves issues where bootstrap may fail but Spegel keeps on running.