### PR TITLE
Remove ConfigMap from RBAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- [#327](https://github.com/XenitAB/spegel/pull/327) Remove ConfigMap from RBAC.
+
 ### Fixed
 
 ### Security

--- a/charts/spegel/templates/rbac.yaml
+++ b/charts/spegel/templates/rbac.yaml
@@ -18,9 +18,6 @@ metadata:
   labels:
     {{- include "spegel.labels" . | nindent 4 }}
 rules:
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["get", "watch", "list", "create", "update"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update"]


### PR DESCRIPTION
Changes made in #325 removed the need for ConfigMap permissions as leases are used instead for leader election.