### PR TITLE
Implement changes to Containerd to enable compatibility with k3s

### DIFF
--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -199,7 +199,7 @@ func (c *Containerd) GetImageDigests(ctx context.Context, img Image) ([]string, 
 			var idx ocispec.Index
 			b, err := content.ReadBlob(ctx, client.ContentStore(), desc)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to read blob for manifest list: %w", err)
 			}
 			if err := json.Unmarshal(b, &idx); err != nil {
 				return nil, err
@@ -220,7 +220,7 @@ func (c *Containerd) GetImageDigests(ctx context.Context, img Image) ([]string, 
 			var manifest ocispec.Manifest
 			b, err := content.ReadBlob(ctx, client.ContentStore(), desc)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to read blob for manifest: %w", err)
 			}
 			if err := json.Unmarshal(b, &manifest); err != nil {
 				return nil, err

--- a/pkg/oci/containerd_test.go
+++ b/pkg/oci/containerd_test.go
@@ -243,6 +243,7 @@ func TestGetImageDigestsNoPlatform(t *testing.T) {
 		Name:   "ghcr.io/xenitab/spegel:v0.0.8",
 		Digest: digest.Digest("sha256:e80e36564e9617f684eb5972bf86dc9e9e761216e0d40ff78ca07741ec70725a"),
 	}
+
 	_, err = c.GetImageDigests(context.TODO(), img)
 	require.EqualError(t, err, "failed to walk image manifests: could not find any platforms with local content in manifest list: sha256:e80e36564e9617f684eb5972bf86dc9e9e761216e0d40ff78ca07741ec70725a")
 }

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -69,7 +69,6 @@ func all(ctx context.Context, ociClient oci.Client, router routing.Router, resol
 	if err != nil {
 		return err
 	}
-
 	metrics.AdvertisedKeys.Reset()
 	metrics.AdvertisedImages.Reset()
 	metrics.AdvertisedImageTags.Reset()


### PR DESCRIPTION
These changes implement changes made by the k3s fork of Spegel.

https://github.com/k3s-io/spegel