### PR TITLE
Add support for a custom http transport when proxying requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#340](https://github.com/XenitAB/spegel/pull/340) Add Talos to compatibility.
 - [#343](https://github.com/XenitAB/spegel/pull/343) Implement image event and add support for delete events.
 - [#344](https://github.com/XenitAB/spegel/pull/344) Add support for multi arch images.
+- [#347](https://github.com/XenitAB/spegel/pull/347) Add support for a custom http transport when proxying requests.
 
 ### Changed
 

--- a/main.go
+++ b/main.go
@@ -170,7 +170,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 	})
 
 	// Registry
-	reg := registry.NewRegistry(ociClient, router, args.LocalAddr, args.MirrorResolveRetries, args.MirrorResolveTimeout, args.ResolveLatestTag)
+	reg := registry.NewRegistry(ociClient, router, args.LocalAddr, args.MirrorResolveRetries, args.MirrorResolveTimeout, args.ResolveLatestTag, nil)
 	regSrv := reg.Server(args.RegistryAddr, log)
 	g.Go(func() error {
 		if err := regSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -29,13 +29,14 @@ const (
 type Registry struct {
 	ociClient        oci.Client
 	router           routing.Router
+	transport        http.RoundTripper
 	localAddr        string
 	resolveRetries   int
 	resolveTimeout   time.Duration
 	resolveLatestTag bool
 }
 
-func NewRegistry(ociClient oci.Client, router routing.Router, localAddr string, resolveRetries int, resolveTimeout time.Duration, resolveLatestTag bool) *Registry {
+func NewRegistry(ociClient oci.Client, router routing.Router, localAddr string, resolveRetries int, resolveTimeout time.Duration, resolveLatestTag bool, transport http.RoundTripper) *Registry {
 	return &Registry{
 		ociClient:        ociClient,
 		router:           router,
@@ -43,6 +44,7 @@ func NewRegistry(ociClient oci.Client, router routing.Router, localAddr string, 
 		resolveTimeout:   resolveTimeout,
 		resolveLatestTag: resolveLatestTag,
 		localAddr:        localAddr,
+		transport:        transport,
 	}
 }
 
@@ -154,7 +156,7 @@ func (r *Registry) registryHandler(c *gin.Context) {
 func (r *Registry) handleMirror(c *gin.Context, key string) {
 	c.Set("handler", "mirror")
 
-	log := pkggin.FromContextOrDiscard(c)
+	log := pkggin.FromContextOrDiscard(c).WithValues("key", key, "path", c.Request.URL.Path, "ip", c.RemoteIP())
 
 	// Resolve mirror with the requested key
 	resolveCtx, cancel := context.WithTimeout(c, r.resolveTimeout)
@@ -162,7 +164,7 @@ func (r *Registry) handleMirror(c *gin.Context, key string) {
 	resolveCtx = logr.NewContext(resolveCtx, log)
 	isExternal := r.isExternalRequest(c)
 	if isExternal {
-		log.Info("handling mirror request from external node", "path", c.Request.URL.Path, "ip", c.RemoteIP())
+		log.Info("handling mirror request from external node")
 	}
 	peerCh, err := r.router.Resolve(resolveCtx, key, isExternal, r.resolveRetries)
 	if err != nil {
@@ -200,7 +202,10 @@ func (r *Registry) handleMirror(c *gin.Context, key string) {
 				Host:   ipAddr.String(),
 			}
 			proxy := httputil.NewSingleHostReverseProxy(u)
-			proxy.ErrorHandler = func(http.ResponseWriter, *http.Request, error) {}
+			proxy.Transport = r.transport
+			proxy.ErrorHandler = func(_ http.ResponseWriter, _ *http.Request, err error) {
+				log.Error(err, "proxy failed attempting next")
+			}
 			proxy.ModifyResponse = func(resp *http.Response) error {
 				if resp.StatusCode != http.StatusOK {
 					err := fmt.Errorf("expected mirror to respond with 200 OK but received: %s", resp.Status)

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -65,7 +65,7 @@ func TestMirrorHandler(t *testing.T) {
 		"last-peer-working": {badAddrPort, badAddrPort, goodAddrPort},
 	}
 	router := routing.NewMockRouter(resolver, netip.AddrPort{})
-	reg := NewRegistry(nil, router, "", 3, 5*time.Second, false)
+	reg := NewRegistry(nil, router, "", 3, 5*time.Second, false, nil)
 
 	tests := []struct {
 		expectedHeaders map[string][]string


### PR DESCRIPTION
This will enable use of for example custom client certificates when proxying http requests.

Part of fixing compatibility with k3s.