### PR TITLE
Remove state track retry on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- [#371](https://github.com/XenitAB/spegel/pull/371) Remove state track retry on error.
+
 ### Fixed
 
 ### Security

--- a/main.go
+++ b/main.go
@@ -167,7 +167,10 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 
 	// State tracking
 	g.Go(func() error {
-		state.Track(ctx, ociClient, router, args.ResolveLatestTag)
+		err := state.Track(ctx, ociClient, router, args.ResolveLatestTag)
+		if err != nil {
+			return err
+		}
 		return nil
 	})
 

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -49,7 +49,8 @@ func TestBasic(t *testing.T) {
 				time.Sleep(2 * time.Second)
 				cancel()
 			}()
-			Track(ctx, ociClient, router, tt.resolveLatestTag)
+			err := Track(ctx, ociClient, router, tt.resolveLatestTag)
+			require.NoError(t, err)
 
 			for _, img := range imgs {
 				peers, ok := router.LookupKey(img.Digest.String())


### PR DESCRIPTION
PR #343 implemented a retry logic for state tracking. This was for the most important for k3s to make sure that state tracking does not just stop. This had the side effect that state tracking would retry immediately on any error. Before this change when an error occurred, it would be logged and tracking would be attempted again after the ticker.

With the current solution if an image with an invalid name exists on the node the tracking will end up in a infinite retry loop without any delay, which may consume more CPU time than wanted.

@brandond any retry looping should be re implemented in k3s.