### PR TITLE
feat: add `https://cgr.dev` to default Helm registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#386](https://github.com/XenitAB/spegel/pull/386) Add contributing guide.
 - [#391](https://github.com/XenitAB/spegel/pull/391) Add documentation for EKS specific Containerd configuration.
 - [#393](https://github.com/XenitAB/spegel/pull/393) Add environment variable configuration support.
+- [#394](https://github.com/XenitAB/spegel/pull/394) Add `cgr.dev` to default registry mirrors in the Helm chart.
 
 ### Changed
 

--- a/charts/spegel/README.md
+++ b/charts/spegel/README.md
@@ -91,7 +91,7 @@ spec:
 | spegel.kubeconfigPath | string | `""` | Path to Kubeconfig credentials, should only be set if Spegel is run in an environment without RBAC. |
 | spegel.mirrorResolveRetries | int | `3` | Max ammount of mirrors to attempt. |
 | spegel.mirrorResolveTimeout | string | `"5s"` | Max duration spent finding a mirror. |
-| spegel.registries | list | `["https://docker.io","https://ghcr.io","https://quay.io","https://mcr.microsoft.com","https://public.ecr.aws","https://gcr.io","https://registry.k8s.io","https://k8s.gcr.io","https://lscr.io"]` | Registries for which mirror configuration will be created. |
+| spegel.registries | list | `["https://cgr.dev","https://docker.io","https://ghcr.io","https://quay.io","https://mcr.microsoft.com","https://public.ecr.aws","https://gcr.io","https://registry.k8s.io","https://k8s.gcr.io","https://lscr.io"]` | Registries for which mirror configuration will be created. |
 | spegel.resolveLatestTag | bool | `true` | When true latest tags will be resolved to digests. |
 | spegel.resolveTags | bool | `true` | When true Spegel will resolve tags to digests. |
 | tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoExecute","operator":"Exists"},{"effect":"NoSchedule","operator":"Exists"}]` | Tolerations for pod assignment. |

--- a/charts/spegel/values.yaml
+++ b/charts/spegel/values.yaml
@@ -110,6 +110,7 @@ priorityClassName: system-node-critical
 spegel:
   # -- Registries for which mirror configuration will be created.
   registries:
+    - https://cgr.dev
     - https://docker.io
     - https://ghcr.io
     - https://quay.io


### PR DESCRIPTION
Adds chainguards container registry to default helm values