### PR TITLE
Fix missing metrics when registering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#396](https://github.com/XenitAB/spegel/pull/396) Fix missing metrics when registering.
+
 ### Security
 
 ## v0.0.18

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -40,5 +40,7 @@ var (
 func Register() {
 	DefaultRegisterer.MustRegister(MirrorRequestsTotal)
 	DefaultRegisterer.MustRegister(AdvertisedImages)
+	DefaultRegisterer.MustRegister(AdvertisedImageTags)
+	DefaultRegisterer.MustRegister(AdvertisedImageDigests)
 	DefaultRegisterer.MustRegister(AdvertisedKeys)
 }


### PR DESCRIPTION
Somewhere along the line when the new metrics were added I forgot to add them to the register function. This adds those metrics to the register function.