### PR TITLE
Replace CopyLayer with GetBlob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#367](https://github.com/XenitAB/spegel/pull/367) Update Go image to 1.21.7.
 - [#376](https://github.com/XenitAB/spegel/pull/376) Change go directive to 1.21.
 - [#383](https://github.com/XenitAB/spegel/pull/383) Bump libp2p to v0.33.0, replace deprecated Pretty function
+- [#397](https://github.com/XenitAB/spegel/pull/397) Replace CopyLayer with GetBlob.
 
 ### Deprecated
 

--- a/pkg/oci/containerd.go
+++ b/pkg/oci/containerd.go
@@ -304,6 +304,24 @@ func (c *Containerd) GetManifest(ctx context.Context, dgst digest.Digest) ([]byt
 	return b, mt, nil
 }
 
+func (c *Containerd) GetBlob(ctx context.Context, dgst digest.Digest) (io.ReadCloser, error) {
+	client, err := c.Client()
+	if err != nil {
+		return nil, err
+	}
+	ra, err := client.ContentStore().ReaderAt(ctx, ocispec.Descriptor{Digest: dgst})
+	if err != nil {
+		return nil, err
+	}
+	return struct {
+		io.Reader
+		io.Closer
+	}{
+		Reader: content.NewReader(ra),
+		Closer: ra,
+	}, nil
+}
+
 func (c *Containerd) CopyLayer(ctx context.Context, dgst digest.Digest, dst io.Writer) error {
 	client, err := c.Client()
 	if err != nil {

--- a/pkg/oci/mock.go
+++ b/pkg/oci/mock.go
@@ -51,6 +51,10 @@ func (m *MockClient) GetManifest(ctx context.Context, dgst digest.Digest) ([]byt
 	return nil, "", nil
 }
 
+func (m *MockClient) GetBlob(ctx context.Context, dgst digest.Digest) (io.ReadCloser, error) {
+	return nil, nil
+}
+
 func (m *MockClient) CopyLayer(ctx context.Context, dgst digest.Digest, dst io.Writer) error {
 	return nil
 }

--- a/pkg/oci/oci.go
+++ b/pkg/oci/oci.go
@@ -20,5 +20,7 @@ type Client interface {
 	Resolve(ctx context.Context, ref string) (digest.Digest, error)
 	Size(ctx context.Context, dgst digest.Digest) (int64, error)
 	GetManifest(ctx context.Context, dgst digest.Digest) ([]byte, string, error)
+	GetBlob(ctx context.Context, dgst digest.Digest) (io.ReadCloser, error)
+	// Deprecated: Use GetBlob.
 	CopyLayer(ctx context.Context, dgst digest.Digest, dst io.Writer) error
 }

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -1,9 +1,9 @@
 package oci
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path"
 	"testing"
@@ -133,10 +133,12 @@ func TestOCIClient(t *testing.T) {
 						require.Equal(t, tt.mediaType, mediaType)
 						require.Equal(t, blobs[tt.dgst], b)
 					} else {
-						var buf bytes.Buffer
-						err = ociClient.CopyLayer(ctx, tt.dgst, &buf)
+						rc, err := ociClient.GetBlob(ctx, tt.dgst)
 						require.NoError(t, err)
-						require.Equal(t, blobs[tt.dgst], buf.Bytes())
+						defer rc.Close()
+						b, err := io.ReadAll(rc)
+						require.NoError(t, err)
+						require.Equal(t, blobs[tt.dgst], b)
 					}
 				})
 			}


### PR DESCRIPTION
This change moves the burden of copying blobs from the oci client to the registry handler. It mimics the GetManifest function better and will make more sense for future alternative oci client implementations.